### PR TITLE
Bumped hyper version to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bench = false
 
 [dependencies]
 rustc-serialize = "0.3"
-hyper = { version = "0.7.2", optional = true, default-features = false }
+hyper = { version = "0.9", optional = true, default-features = false }
 log = "0.3"
 winapi = "0.2"
 secur32-sys="0.2"


### PR DESCRIPTION
Schannel needs to implement hyper::net::SslClient to work with code that uses hyper 0.9, and it gets this for free if its own dependency is set to 0.9
