### PR TITLE
Add a verification callback.

### DIFF
--- a/src/cert_chain.rs
+++ b/src/cert_chain.rs
@@ -8,6 +8,7 @@ use winapi;
 use cert_context::CertContext;
 use Inner;
 
+/// A certificate chain context (consisting of multiple chains)
 pub struct CertChainContext(pub winapi::PCERT_CHAIN_CONTEXT);
 
 impl Clone for CertChainContext {
@@ -44,6 +45,7 @@ impl CertChainContext {
     }
 }
 
+/// A (simple) certificate chain 
 pub struct CertChain(winapi::PCERT_SIMPLE_CHAIN, CertChainContext);
 
 impl CertChain {
@@ -81,6 +83,7 @@ impl CertChain {
     }
 }
 
+/// An iterator that iterates over all certificates in a chain
 pub struct Certificates<'a> {
     chain: &'a CertChain,
     idx: usize,

--- a/src/cert_chain.rs
+++ b/src/cert_chain.rs
@@ -1,0 +1,97 @@
+//! Bindings to winapi's certificate-chain related APIs.
+
+use std::mem;
+use std::slice;
+use crypt32;
+use winapi;
+
+use cert_context::CertContext;
+use Inner;
+
+pub struct CertChainContext(pub winapi::PCERT_CHAIN_CONTEXT);
+
+impl Clone for CertChainContext {
+    fn clone(&self) -> Self {
+        let rced = unsafe {
+            crypt32::CertDuplicateCertificateChain(self.0) as *mut _
+        };
+        CertChainContext(rced)
+    }
+}
+
+impl Drop for CertChainContext {
+    fn drop(&mut self) {
+        unsafe {
+            crypt32::CertFreeCertificateChain(self.0);
+        }
+    }
+}
+
+impl CertChainContext {
+    /// Get the final (for a successful verification this means successful) certificate chain
+    ///
+    /// https://msdn.microsoft.com/de-de/library/windows/desktop/aa377182(v=vs.85).aspx
+    /// rgpChain[cChain - 1] is the final chain
+    pub fn final_chain(&self) -> Option<CertChain> {
+        let cloned = self.clone();
+        let chains = unsafe {
+            let cert_chain = *cloned.0;
+            slice::from_raw_parts(
+                cert_chain.rgpChain as *mut winapi::PCERT_SIMPLE_CHAIN,
+                cert_chain.cChain as usize)
+        };
+        chains.last().map(|chain| CertChain(*chain, cloned))
+    }
+}
+
+pub struct CertChain(winapi::PCERT_SIMPLE_CHAIN, CertChainContext);
+
+impl CertChain {
+    /// Returns the number of certificates in the chain
+    pub fn len(&self) -> usize {
+        unsafe {
+            (*self.0).cElement as usize
+        }
+    }
+
+    /// Get the n-th certificate from the current chain
+    pub fn get(&self, idx: usize) -> Option<CertContext> {
+        let elements = unsafe {
+            let cert_chain = *self.0;
+            slice::from_raw_parts(
+                cert_chain.rgpElement as *mut &mut winapi::CERT_CHAIN_ELEMENT,
+                cert_chain.cElement as usize)
+        };
+        elements.get(idx).map(|el| {
+            let cert = unsafe {
+                CertContext::from_inner(el.pCertContext)
+            };
+            let rc_cert = cert.clone();
+            mem::forget(cert);
+            rc_cert
+        })
+    }
+
+    /// Return an iterator over all certificates in this chain
+    pub fn certificates(&self) -> Certificates {
+        Certificates {
+            chain: self,
+            idx: 0,
+        }
+    }
+}
+
+pub struct Certificates<'a> {
+    chain: &'a CertChain,
+    idx: usize,
+}
+
+impl<'a> Iterator for Certificates<'a> {
+    type Item = CertContext;
+
+    fn next(&mut self) -> Option<CertContext> {
+        let idx = self.idx;
+        self.idx += 1;
+        self.chain.get(idx)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ use std::ptr;
 
 use key_handle::KeyHandle;
 
+pub mod cert_chain;
 pub mod cert_context;
 pub mod cert_store;
 /* pub */ mod ctl_context;

--- a/src/test.rs
+++ b/src/test.rs
@@ -197,6 +197,47 @@ fn validation_failure_is_permanent() {
                winapi::CERT_E_UNTRUSTEDROOT as i32);
 }
 
+#[test]
+fn verify_callback_success() {
+    let creds = SchannelCred::builder()
+        .acquire(Direction::Outbound)
+        .unwrap();
+    let stream = TcpStream::connect("self-signed.badssl.com:443").unwrap();
+    let mut stream = tls_stream::Builder::new()
+        .domain("self-signed.badssl.com")
+        .verify_callback(|status, _| {
+            assert_eq!(status, false);
+            true
+        })
+        .connect(creds, stream)
+        .unwrap();
+    stream.write_all(b"GET / HTTP/1.0\r\nHost: self-signed.badssl.com\r\n\r\n").unwrap();
+    let mut out = vec![];
+    stream.read_to_end(&mut out).unwrap();
+    assert!(out.starts_with(b"HTTP/1.1 200 OK"));
+    assert!(out.ends_with(b"</html>\n"));
+}
+
+#[test]
+fn verify_callback_error() {
+    let creds = SchannelCred::builder()
+        .acquire(Direction::Outbound)
+        .unwrap();
+    let stream = TcpStream::connect("google.com:443").unwrap();
+    let err = tls_stream::Builder::new()
+        .domain("google.com")
+        .verify_callback(|status, _| {
+            assert_eq!(status, true);
+            false
+        })
+        .connect(creds, stream)
+        .err()
+        .unwrap();
+    let err = unwrap_handshake(err);
+    assert_eq!(err.raw_os_error().unwrap(),
+               winapi::CERT_E_UNTRUSTEDROOT as i32);
+}
+
 const FRIENDLY_NAME: &'static str = "schannel-rs localhost testing cert";
 
 lazy_static! {

--- a/src/test.rs
+++ b/src/test.rs
@@ -206,8 +206,8 @@ fn verify_callback_success() {
     let mut stream = tls_stream::Builder::new()
         .domain("self-signed.badssl.com")
         .verify_callback(|status, _| {
-            assert_eq!(status, false);
-            true
+            assert!(status.is_err());
+            Ok(())
         })
         .connect(creds, stream)
         .unwrap();
@@ -227,8 +227,8 @@ fn verify_callback_error() {
     let err = tls_stream::Builder::new()
         .domain("google.com")
         .verify_callback(|status, _| {
-            assert_eq!(status, true);
-            false
+            assert!(status.is_ok());
+            Err(io::Error::from_raw_os_error(winapi::CERT_E_UNTRUSTEDROOT))
         })
         .connect(creds, stream)
         .err()

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -9,10 +9,11 @@ use std::io::{self, Read, BufRead, Write, Cursor};
 use std::mem;
 use std::ptr;
 use std::slice;
+use std::sync::Arc;
 use winapi;
 
 use {INIT_REQUESTS, ACCEPT_REQUESTS, Inner, secbuf, secbuf_desc};
-use cert_context::CertContext;
+use cert_chain::{CertChain, CertChainContext};
 use cert_store::CertStore;
 use security_context::SecurityContext;
 use context_buffer::ContextBuffer;
@@ -27,20 +28,11 @@ lazy_static! {
         winapi::szOID_SGC_NETSCAPE.bytes().chain(Some(0)).collect();
 }
 
-struct CertChainContext(winapi::PCERT_CHAIN_CONTEXT);
-
-impl Drop for CertChainContext {
-    fn drop(&mut self) {
-        unsafe {
-            crypt32::CertFreeCertificateChain(self.0);
-        }
-    }
-}
-
 /// A builder type for `TlsStream`s.
-#[derive(Default, Debug)]
+#[derive(Default)]
 pub struct Builder {
     domain: Option<Vec<u16>>,
+    verify_callback: Option<Arc<Fn(bool, &CertChain) -> bool>>,
     cert_store: Option<CertStore>,
     accept: bool,
 }
@@ -57,6 +49,17 @@ impl Builder {
     /// certificate validation.
     pub fn domain(&mut self, domain: &str) -> &mut Builder {
         self.domain = Some(domain.encode_utf16().chain(Some(0)).collect());
+        self
+    }
+
+    /// Set a verification callback to be used for connections created with this `Builder`.
+    ///
+    /// The callback is provided with a boolean indicating if the (pre)validation was
+    /// successful and with the certificate, which was validated.
+    pub fn verify_callback<F>(&mut self, callback: F) -> &mut Builder 
+        where F: Fn(bool, &CertChain) -> bool + 'static
+    {
+        self.verify_callback = Some(Arc::new(callback));
         self
     }
 
@@ -131,6 +134,7 @@ impl Builder {
             context: ctxt,
             cert_store: self.cert_store.clone(),
             domain: self.domain.clone(),
+            verify_callback: self.verify_callback.clone(),
             stream: stream,
             accept: accept,
             accept_first: true,
@@ -138,6 +142,7 @@ impl Builder {
                 needs_flush: false,
                 more_calls: true,
                 shutting_down: false,
+                validated: false,
             },
             needs_read: 1,
             dec_in: Cursor::new(Vec::new()),
@@ -156,6 +161,7 @@ enum State {
         needs_flush: bool,
         more_calls: bool,
         shutting_down: bool,
+        validated: bool,
     },
     Streaming { sizes: winapi::SecPkgContext_StreamSizes, },
     Shutdown,
@@ -167,6 +173,7 @@ pub struct TlsStream<S> {
     context: SecurityContext,
     cert_store: Option<CertStore>,
     domain: Option<Vec<u16>>,
+    verify_callback: Option<Arc<Fn(bool, &CertChain) -> bool>>,
     stream: S,
     state: State,
     accept: bool,
@@ -279,6 +286,7 @@ impl<S> TlsStream<S>
                     needs_flush: false,
                     more_calls: true,
                     shutting_down: true,
+                    validated: false,
                 };
                 self.needs_read = 0;
             }
@@ -412,7 +420,7 @@ impl<S> TlsStream<S>
     fn initialize(&mut self) -> io::Result<Option<winapi::SecPkgContext_StreamSizes>> {
         loop {
             match self.state {
-                State::Initializing { mut needs_flush, more_calls, shutting_down } => {
+                State::Initializing { mut needs_flush, more_calls, shutting_down, validated } => {
                     if try!(self.write_out()) > 0 {
                         needs_flush = true;
                         if let State::Initializing { ref mut needs_flush, .. } = self.state {
@@ -427,14 +435,21 @@ impl<S> TlsStream<S>
                         }
                     }
 
+                    if !shutting_down && !validated {
+                        // on the last call, we require a valid certificate
+                        if try!(self.validate(!more_calls)) {
+                            if let State::Initializing { ref mut validated, .. } = self.state {
+                                *validated = true;
+                            }
+                        }
+                    }
+
                     if !more_calls {
                         self.state = if shutting_down {
                             State::Shutdown
                         } else {
-                            try!(self.validate());
                             State::Streaming { sizes: try!(self.context.stream_sizes()) }
                         };
-
                         continue;
                     }
 
@@ -453,14 +468,20 @@ impl<S> TlsStream<S>
         }
     }
 
-    fn validate(&mut self) -> io::Result<()> {
+    /// Returns true when the certificate was succesfully verified
+    /// Returns false, when a verification isn't necessary (yet)
+    /// Returns an error when the verification failed
+    fn validate(&mut self, require_cert: bool) -> io::Result<bool> {
         // If we're accepting connections then we don't perform any validation
         // for the remote certificate, that's what they're doing!
         if self.accept {
-            return Ok(())
+            return Ok(false);
         }
 
-        let cert_context = try!(self.context.remote_cert());
+        let cert_context = match self.context.remote_cert() {
+            Err(_) if !require_cert => return Ok(false),
+            ret => try!(ret)
+        };
 
         let cert_chain = unsafe {
             let cert_store = self.cert_store
@@ -504,24 +525,10 @@ impl<S> TlsStream<S>
             // check if we trust the root-CA explicitly
             let mut para_flags = winapi::CERT_CHAIN_POLICY_IGNORE_ALL_REV_UNKNOWN_FLAGS;
             if let Some(ref mut store) = self.cert_store {
-                let cert_chain = *cert_chain.0;
-                if cert_chain.cChain > 0 {
-                    let first_rgp_chain = **cert_chain.rgpChain;
-                    if first_rgp_chain.cElement > 0 {
-                        let elements = slice::from_raw_parts(
-                            first_rgp_chain.rgpElement as *mut &mut winapi::CERT_CHAIN_ELEMENT,
-                            first_rgp_chain.cElement as usize);
-                        let final_element = elements.last().unwrap();
-
-                        let root_cert = CertContext::from_inner(final_element.pCertContext);
-                        // find the first cert that matches this root_cert
-                        let cert_match = store.certs()
-                             .map(|cert| cert == root_cert)
-                             .any(|found| found);
-                        mem::forget(root_cert);
-                        if cert_match {
-                            para_flags |= winapi::CERT_CHAIN_POLICY_ALLOW_UNKNOWN_CA_FLAG;
-                        }
+                if let Some(chain) = cert_chain.final_chain() {
+                    // check if any cert of the chain is in the passed store (and therefore trusted)
+                    if chain.certificates().any(|cert| store.certs().any(|root_cert| root_cert == cert)) {
+                        para_flags |= winapi::CERT_CHAIN_POLICY_ALLOW_UNKNOWN_CA_FLAG;
                     }
                 }
             }
@@ -549,12 +556,23 @@ impl<S> TlsStream<S>
                 return Err(io::Error::last_os_error())
             }
 
-            if status.dwError != winapi::ERROR_SUCCESS {
+            let mut verify_result = status.dwError == winapi::ERROR_SUCCESS;
+
+            // check if there's a user-specified verify callback
+            if let Some(ref callback) = self.verify_callback {
+                if let Some(ref chain) = cert_chain.final_chain() {
+                    verify_result = callback(verify_result, chain);
+                    // TODO: not sure if this is the best error
+                    status.dwError = winapi::CERT_E_UNTRUSTEDROOT as u32;
+                }
+            }
+
+            if !verify_result {
                 return Err(io::Error::from_raw_os_error(status.dwError as i32))
             }
         }
 
-        Ok(())
+        Ok(true)
     }
 
     fn write_out(&mut self) -> io::Result<usize> {
@@ -651,6 +669,7 @@ impl<S> TlsStream<S>
                         needs_flush: false,
                         more_calls: true,
                         shutting_down: false,
+                        validated: false,
                     };
 
                     let nread = if bufs[3].BufferType == winapi::SECBUFFER_EXTRA {

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -54,8 +54,10 @@ impl Builder {
 
     /// Set a verification callback to be used for connections created with this `Builder`.
     ///
-    /// The callback is provided with a boolean indicating if the (pre)validation was
-    /// successful and with the certificate, which was validated.
+    /// The callback is provided with an io::Result indicating if the (pre)validation was  
+    /// successful. The Ok() variant indicates a successful validation while the Err() variant  
+    /// contains the errorcode returned from the internal verification process.    
+    /// The validated certificate, is accessible through the second argument of the closure.
     pub fn verify_callback<F>(&mut self, callback: F) -> &mut Builder 
         where F: Fn(io::Result<()>, &CertChain) -> io::Result<()> + 'static
     {


### PR DESCRIPTION
Openssl-inspired implementation of verification callbacks.

TODOs as of now:
- [x] Lifetime's: CertChain should likely borrow/clone CertChainContext!
When the related CertChainContext goes out of scope, CertChain points to invalid memory!
- [x] Tests
- [x] ~~Better solution for the `Arc<Fn...>` ?~~