### PR TITLE
variant of verify_callback with additional context

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -205,8 +205,8 @@ fn verify_callback_success() {
     let stream = TcpStream::connect("self-signed.badssl.com:443").unwrap();
     let mut stream = tls_stream::Builder::new()
         .domain("self-signed.badssl.com")
-        .verify_callback(|status, _| {
-            assert!(status.is_err());
+        .verify_callback(|validation_result| {
+            assert!(validation_result.result().is_err());
             Ok(())
         })
         .connect(creds, stream)
@@ -226,8 +226,8 @@ fn verify_callback_error() {
     let stream = TcpStream::connect("google.com:443").unwrap();
     let err = tls_stream::Builder::new()
         .domain("google.com")
-        .verify_callback(|status, _| {
-            assert!(status.is_ok());
+        .verify_callback(|validation_result| {
+            assert!(validation_result.result().is_ok());
             Err(io::Error::from_raw_os_error(winapi::CERT_E_UNTRUSTEDROOT))
         })
         .connect(creds, stream)
@@ -239,57 +239,16 @@ fn verify_callback_error() {
 }
 
 #[test]
-fn verify_callback2_success() {
-    let creds = SchannelCred::builder()
-        .acquire(Direction::Outbound)
-        .unwrap();
-    let stream = TcpStream::connect("self-signed.badssl.com:443").unwrap();
-    let mut stream = tls_stream::Builder::new()
-        .domain("self-signed.badssl.com")
-        .verify_callback2(|validation_result| {
-            assert!(validation_result.get_result().is_err());
-            Ok(())
-        })
-        .connect(creds, stream)
-        .unwrap();
-    stream.write_all(b"GET / HTTP/1.0\r\nHost: self-signed.badssl.com\r\n\r\n").unwrap();
-    let mut out = vec![];
-    stream.read_to_end(&mut out).unwrap();
-    assert!(out.starts_with(b"HTTP/1.1 200 OK"));
-    assert!(out.ends_with(b"</html>\n"));
-}
-
-#[test]
-fn verify_callback2_error() {
-    let creds = SchannelCred::builder()
-        .acquire(Direction::Outbound)
-        .unwrap();
-    let stream = TcpStream::connect("google.com:443").unwrap();
-    let err = tls_stream::Builder::new()
-        .domain("google.com")
-        .verify_callback2(|validation_result| {
-            assert!(validation_result.get_result().is_ok());
-            Err(io::Error::from_raw_os_error(winapi::CERT_E_UNTRUSTEDROOT))
-        })
-        .connect(creds, stream)
-        .err()
-        .unwrap();
-    let err = unwrap_handshake(err);
-    assert_eq!(err.raw_os_error().unwrap(),
-               winapi::CERT_E_UNTRUSTEDROOT as i32);
-}
-
-#[test]
-fn verify_callback2_gives_failed_cert() {
+fn verify_callback_gives_failed_cert() {
     let creds = SchannelCred::builder()
         .acquire(Direction::Outbound)
         .unwrap();
     let stream = TcpStream::connect("self-signed.badssl.com:443").unwrap();
     let err = tls_stream::Builder::new()
         .domain("self-signed.badssl.com")
-        .verify_callback2(|validation_result| {
+        .verify_callback(|validation_result| {
             let expected_finger = vec!(100, 20, 80, 217, 74, 101, 250, 235, 59, 99, 16, 40, 216, 232, 108, 149, 67, 29, 184, 17);
-            assert_eq!(validation_result.get_failed_certificate().unwrap().fingerprint(HashAlgorithm::sha1()).unwrap(), expected_finger);
+            assert_eq!(validation_result.failed_certificate().unwrap().fingerprint(HashAlgorithm::sha1()).unwrap(), expected_finger);
             Err(io::Error::from_raw_os_error(winapi::CERT_E_UNTRUSTEDROOT))
         })
         .connect(creds, stream)

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -207,7 +207,7 @@ pub struct CertValidationResult {
     res :io::Result<()>,
     chain_index :i32,
     element_index :i32,
-    extra_policy_status :Option<winapi::CERT_CHAIN_POLICY_STATUS>,
+    extra_policy_status : (winapi::LPCSTR, *const winapi::c_void),
 }
 
 impl CertValidationResult {
@@ -580,7 +580,8 @@ impl<S> TlsStream<S>
             let mut status: winapi::CERT_CHAIN_POLICY_STATUS = mem::zeroed();
             status.cbSize = mem::size_of_val(&status) as winapi::DWORD;
 
-            let res = crypt32::CertVerifyCertificateChainPolicy(winapi::CERT_CHAIN_POLICY_SSL as winapi::LPCSTR,
+            let verify_chain_policy_structure = winapi::CERT_CHAIN_POLICY_SSL as winapi::LPCSTR;
+            let res = crypt32::CertVerifyCertificateChainPolicy(verify_chain_policy_structure,
                                                                 cert_chain.0,
                                                                 &mut para,
                                                                 &mut status);
@@ -601,7 +602,7 @@ impl<S> TlsStream<S>
                     res: verify_result,
                     chain_index: status.lChainIndex,
                     element_index: status.lElementIndex,
-                    extra_policy_status: None});
+                    extra_policy_status: (verify_chain_policy_structure, status.pvExtraPolicyStatus)});
             }
             try!(verify_result);
         }


### PR DESCRIPTION
This enables the workfow where an individual needs user confirmation for a failed certificate during verification callback. 