### PR TITLE
Fix wrong Write implementation.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   - TARGET: x86_64-pc-windows-gnu
     VERSION: nightly
   - TARGET: i686-pc-windows-gnu
-    VERSION: 1.10.0
+    VERSION: 1.18.0
   access_token:
     secure: ZxcrtxQXwszRYNN6c1ZIagczEqzmQQZeYHY58izcmF0jdq/cptxJvFUoVxDmnoqj
 install:
@@ -22,4 +22,5 @@ build: off
 
 test_script:
   # TODO remove this loop when server 2016 lands on appveyor; related to https://github.com/steffengy/schannel-rs/issues/8
+  - set RUST_BACKTRACE=1
   - ps: for($i=1; $i -le 3; $i++) { cmd /c "cargo test 2>&1"; if ($?) { break } }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   - TARGET: x86_64-pc-windows-gnu
     VERSION: nightly
   - TARGET: i686-pc-windows-gnu
-    VERSION: 1.18.0
+    VERSION: 1.10.0
   access_token:
     secure: ZxcrtxQXwszRYNN6c1ZIagczEqzmQQZeYHY58izcmF0jdq/cptxJvFUoVxDmnoqj
 install:

--- a/src/test.rs
+++ b/src/test.rs
@@ -48,16 +48,16 @@ fn valid_algorithms() {
         .supported_algorithms(&[Algorithm::Aes128, Algorithm::Ecdsa])
         .acquire(Direction::Outbound)
         .unwrap();
-    let stream = TcpStream::connect("google.com:443").unwrap();
+    let stream = TcpStream::connect("httpbin.org:443").unwrap();
     let mut stream = tls_stream::Builder::new()
-        .domain("google.com")
+        .domain("httpbin.org")
         .connect(creds, stream)
         .unwrap();
-    stream.write_all(b"GET / HTTP/1.0\r\n\r\n").unwrap();
+    stream.write_all(b"GET /get HTTP/1.0\r\nHost: httpbin.org\r\n\r\n").unwrap();
+    stream.flush().unwrap();
     let mut out = vec![];
     stream.read_to_end(&mut out).unwrap();
-    assert!(out.starts_with(b"HTTP/1.0 200 OK"));
-    assert!(out.ends_with(b"</html>"));
+    assert!(out.starts_with(b"HTTP/1.1 200 OK"));
 }
 
 fn unwrap_handshake<S>(e: HandshakeError<S>) -> io::Error {

--- a/src/test.rs
+++ b/src/test.rs
@@ -21,16 +21,16 @@ use tls_stream::{self, HandshakeError};
 #[test]
 fn basic() {
     let creds = SchannelCred::builder().acquire(Direction::Outbound).unwrap();
-    let stream = TcpStream::connect("google.com:443").unwrap();
+    let stream = TcpStream::connect("httpbin.org:443").unwrap();
     let mut stream = tls_stream::Builder::new()
-        .domain("google.com")
+        .domain("httpbin.org")
         .connect(creds, stream)
         .unwrap();
-    stream.write_all(b"GET / HTTP/1.0\r\n\r\n").unwrap();
+    stream.write_all(b"GET /get HTTP/1.0\r\nHost: httpbin.org\r\n\r\n").unwrap();
+    stream.flush().unwrap();
     let mut out = vec![];
     stream.read_to_end(&mut out).unwrap();
-    assert!(out.starts_with(b"HTTP/1.0 200 OK"));
-    assert!(out.ends_with(b"</html>"));
+    assert!(out.starts_with(b"HTTP/1.1 200 OK"));
 }
 
 #[test]
@@ -91,16 +91,16 @@ fn valid_protocol() {
         .enabled_protocols(&[Protocol::Tls12])
         .acquire(Direction::Outbound)
         .unwrap();
-    let stream = TcpStream::connect("google.com:443").unwrap();
+    let stream = TcpStream::connect("httpbin.org:443").unwrap();
     let mut stream = tls_stream::Builder::new()
-        .domain("google.com")
+        .domain("httpbin.org")
         .connect(creds, stream)
         .unwrap();
-    stream.write_all(b"GET / HTTP/1.0\r\n\r\n").unwrap();
+    stream.write_all(b"GET /get HTTP/1.0\r\nHost: httpbin.org\r\n\r\n").unwrap();
+    stream.flush().unwrap();
     let mut out = vec![];
     stream.read_to_end(&mut out).unwrap();
-    assert!(out.starts_with(b"HTTP/1.0 200 OK"));
-    assert!(out.ends_with(b"</html>"));
+    assert!(out.starts_with(b"HTTP/1.1 200 OK"));
 }
 
 #[test]
@@ -213,6 +213,7 @@ fn verify_callback_success() {
         .connect(creds, stream)
         .unwrap();
     stream.write_all(b"GET / HTTP/1.0\r\nHost: self-signed.badssl.com\r\n\r\n").unwrap();
+    stream.flush().unwrap();
     let mut out = vec![];
     stream.read_to_end(&mut out).unwrap();
     assert!(out.starts_with(b"HTTP/1.1 200 OK"));

--- a/src/test.rs
+++ b/src/test.rs
@@ -45,7 +45,7 @@ fn invalid_algorithms() {
 #[test]
 fn valid_algorithms() {
     let creds = SchannelCred::builder()
-        .supported_algorithms(&[Algorithm::Aes128, Algorithm::Ecdsa])
+        .supported_algorithms(&[Algorithm::Aes128])
         .acquire(Direction::Outbound)
         .unwrap();
     let stream = TcpStream::connect("httpbin.org:443").unwrap();

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -821,8 +821,8 @@ impl<S> Write for TlsStream<S>
     }
 
     fn flush(&mut self) -> io::Result<()> {
-		// Make sure the write buffer is emptied
-		self.write_out()?;
+        // Make sure the write buffer is emptied
+        self.write_out()?;
         self.stream.flush()
     }
 }

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -733,11 +733,7 @@ impl<S> TlsStream<S>
         let len = sizes.cbHeader as usize + buf.len() + sizes.cbTrailer as usize;
 
         self.out_buf.set_position(0);
-        if self.out_buf.get_ref().len() < len {
-            self.out_buf.get_mut().resize(len, 0);
-        } else {
-            self.out_buf.get_mut().truncate(len); // Does not change capacity
-        }
+        self.out_buf.get_mut().resize(len, 0);
 
         let message_start = sizes.cbHeader as usize;
         self.out_buf
@@ -762,6 +758,8 @@ impl<S> TlsStream<S>
 
             match secur32::EncryptMessage(self.context.get_mut(), 0, &mut bufdesc, 0) {
                 winapi::SEC_E_OK => {
+                    let len = bufs[0].cbBuffer + bufs[1].cbBuffer + bufs[2].cbBuffer;
+                    self.out_buf.get_mut().truncate(len as usize);
                     Ok(())
                 }
                 err => Err(io::Error::from_raw_os_error(err as i32)),

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -800,8 +800,8 @@ impl<S> Write for TlsStream<S>
             None => return Err(io::Error::from_raw_os_error(winapi::SEC_E_CONTEXT_EXPIRED as i32)),
         };
 		
-		// We can only write if the write buffer is emptied first
-		self.write_out()?;
+        // We can only write if the write buffer is emptied first
+        self.write_out()?;
 
         let len = cmp::min(buf.len(), sizes.cbMaximumMessage as usize);
 

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -626,7 +626,7 @@ impl<S> TlsStream<S>
         }
 
         Ok(out)
-	}
+    }
 
     fn read_in(&mut self) -> io::Result<usize> {
         let mut sum_nread = 0;


### PR DESCRIPTION
Fixes https://github.com/steffengy/schannel-rs/issues/34

I believe this is a solution which is both efficient by not discarding earlier encrypted bytes and correct by abiding the rules of the `Write` trait.