### PR TITLE
Feature/key info

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -168,29 +168,6 @@ fn wrong_host_cert() {
 }
 
 #[test]
-fn key_usage() {
-    println!("opening store");
-    if let Ok(mut cert_store) = CertStore::open_current_user("My") {
-        println!("open");
-        let mut num_sigs = 0;
-        for cert in cert_store.certs() {
-            println!("cert: {:?}", cert.sha1());
-            if let Some(usage) = cert.key_usage() {
-                if usage.contains("Digital Signature") {
-                    println!("Signature");                    
-                    num_sigs = num_sigs + 1;
-                } else {
-                    println!("Not a signature");                    
-                }
-            } else {
-                println!("No usage");                                    
-            }
-        }
-        assert_eq!(num_sigs, 3);
-    }
-}
-
-#[test]
 fn shutdown() {
     let creds = SchannelCred::builder().acquire(Direction::Outbound).unwrap();
     let stream = TcpStream::connect("google.com:443").unwrap();

--- a/src/test.rs
+++ b/src/test.rs
@@ -168,6 +168,27 @@ fn wrong_host_cert() {
 }
 
 #[test]
+fn key_usage() {
+    if let Ok(mut cert_store) = CertStore::open_current_user("My") {
+        let mut num_sigs = 0;
+        for cert in cert_store.certs() {
+            println!("cert: {:?}", cert.sha1());
+            if let Some(usage) = cert.key_usage() {
+                if usage.is_digital_signature() {
+                    println!("Signature");                    
+                    num_sigs = num_sigs + 1;
+                } else {
+                    println!("Not a signature");                    
+                }
+            } else {
+                println!("No usage");                                    
+            }
+        }
+        assert_eq!(num_sigs, 3);
+    }
+}
+
+#[test]
 fn shutdown() {
     let creds = SchannelCred::builder().acquire(Direction::Outbound).unwrap();
     let stream = TcpStream::connect("google.com:443").unwrap();

--- a/src/test.rs
+++ b/src/test.rs
@@ -169,12 +169,14 @@ fn wrong_host_cert() {
 
 #[test]
 fn key_usage() {
+    println!("opening store");
     if let Ok(mut cert_store) = CertStore::open_current_user("My") {
+        println!("open");
         let mut num_sigs = 0;
         for cert in cert_store.certs() {
             println!("cert: {:?}", cert.sha1());
             if let Some(usage) = cert.key_usage() {
-                if usage.is_digital_signature() {
+                if usage.contains("Digital Signature") {
                     println!("Signature");                    
                     num_sigs = num_sigs + 1;
                 } else {


### PR DESCRIPTION
This function adds the ability to gather the Key Usage info in string format from a security context. 

This can be used to filter certs provided to a Tls_Stream in the security context such that non-signature keys are not supplied. I have been experiencing issues where the server requests client certificate validation but the client supplies symmetric (S/MIME) keys, causing the request to crash server-side. 