### PR TITLE
restore behavior to write_out without requiring an explicit flush

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -27,7 +27,6 @@ fn basic() {
         .connect(creds, stream)
         .unwrap();
     stream.write_all(b"GET / HTTP/1.0\r\n\r\n").unwrap();
-    stream.flush().unwrap();
     let mut out = vec![];
     stream.read_to_end(&mut out).unwrap();
     assert!(out.starts_with(b"HTTP/1.0 200 OK") || out.starts_with(b"HTTP/1.0 302 Found"));
@@ -55,7 +54,6 @@ fn valid_algorithms() {
         .connect(creds, stream)
         .unwrap();
     stream.write_all(b"GET / HTTP/1.0\r\n\r\n").unwrap();
-    stream.flush().unwrap();
     let mut out = vec![];
     stream.read_to_end(&mut out).unwrap();
     assert!(out.starts_with(b"HTTP/1.0 200 OK") || out.starts_with(b"HTTP/1.0 302 Found"));
@@ -99,7 +97,6 @@ fn valid_protocol() {
         .connect(creds, stream)
         .unwrap();
     stream.write_all(b"GET / HTTP/1.0\r\n\r\n").unwrap();
-    stream.flush().unwrap();
     let mut out = vec![];
     stream.read_to_end(&mut out).unwrap();
     assert!(out.starts_with(b"HTTP/1.0 200 OK") || out.starts_with(b"HTTP/1.0 302 Found"));
@@ -216,7 +213,6 @@ fn verify_callback_success() {
         .connect(creds, stream)
         .unwrap();
     stream.write_all(b"GET / HTTP/1.0\r\nHost: self-signed.badssl.com\r\n\r\n").unwrap();
-    stream.flush().unwrap();
     let mut out = vec![];
     stream.read_to_end(&mut out).unwrap();
     assert!(out.starts_with(b"HTTP/1.1 200 OK"));

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -628,7 +628,6 @@ impl<S> TlsStream<S>
             self.out_buf.set_position((position + nwritten) as u64);
         }
 
-        self.last_write_len = 0;
         Ok(out)
     }
 

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -811,7 +811,9 @@ impl<S> Write for TlsStream<S>
 
         try!(self.encrypt(&buf[..len], &sizes));
 
-        // Pretend we wrote everything because we put it on the write buffer
+        try!(self.write_out());
+
+
         Ok(len)
     }
 


### PR DESCRIPTION
cc @sfackler

Not sure this needs to ignore some kinds of errors?
Seems to atleast not break anything immediately, but I'm having
a feeling of missing something here.

Related to #34