### PR TITLE
allow retrieving certs as pem or der and their valid use oids

### DIFF
--- a/src/cert_context.rs
+++ b/src/cert_context.rs
@@ -301,7 +301,7 @@ impl CertContext {
                         .into_owned(),
                 );
             }
-            Ok(ValidUses::OIDs(oids))
+            Ok(ValidUses::Oids(oids))
         }
     }
 
@@ -565,14 +565,14 @@ impl KeySpec {
     }
 }
 
-/// Valid uses of a Certificate - All, None, or specific OIDs
+/// Valid uses of a Certificate - All, or specific OIDs
 pub enum ValidUses {
     /// Certificate is valid for all uses
     All,
 
     /// Certificate is valid for uses specified. No entries means that the certificate
     /// has no valid uses.
-    OIDs(Vec<String>),
+    Oids(Vec<String>),
 }
 
 #[cfg(test)]

--- a/src/cert_context.rs
+++ b/src/cert_context.rs
@@ -285,10 +285,10 @@ impl CertContext {
             let use_cnt = (*cert_enhkey_usage).cUsageIdentifier;
             if use_cnt == 0 {
                 let last_error = io::Error::last_os_error();
-                return match last_error.raw_os_error() {
-                    Some(winapi::winerror::CRYPT_E_NOT_FOUND) => Ok(ValidUses::All),
-                    Some(0) => Ok(ValidUses::OIDs(Vec::new())),
-                    _ => Err(last_error),
+                match last_error.raw_os_error() {
+                    Some(winapi::winerror::CRYPT_E_NOT_FOUND) => return Ok(ValidUses::All),
+                    Some(0) => (),
+                    _ => return Err(last_error),
                 };
             }
 

--- a/src/cert_context.rs
+++ b/src/cert_context.rs
@@ -287,7 +287,7 @@ impl CertContext {
                 let last_error = io::Error::last_os_error();
                 return match last_error.raw_os_error() {
                     Some(winapi::winerror::CRYPT_E_NOT_FOUND) => Ok(ValidUses::All),
-                    Some(0) => Ok(ValidUses::None),
+                    Some(0) => Ok(ValidUses::OIDs(Vec::new())),
                     _ => Err(last_error),
                 };
             }
@@ -570,10 +570,8 @@ pub enum ValidUses {
     /// Certificate is valid for all uses
     All,
 
-    /// Certificate is not valid for any use
-    None,
-
-    /// Certificate is valid for uses specified
+    /// Certificate is valid for uses specified. No entries means that the certificate
+    /// has no valid uses.
     OIDs(Vec<String>),
 }
 

--- a/src/cert_context.rs
+++ b/src/cert_context.rs
@@ -131,7 +131,7 @@ impl CertContext {
             let ok = crypt32::CryptBinaryToStringA(
                 (*self.0).pbCertEncoded,
                 (*self.0).cbCertEncoded,
-                0 as winapi::DWORD,
+                CRYPT_STRING_BASE64HEADER,
                 ptr::null_mut(),
                 &mut len,
             );
@@ -143,7 +143,7 @@ impl CertContext {
             let ok = crypt32::CryptBinaryToStringA(
                 (*self.0).pbCertEncoded,
                 (*self.0).cbCertEncoded,
-                0 as winapi::DWORD,
+                CRYPT_STRING_BASE64HEADER,
                 buf.as_mut_ptr() as *mut i8,
                 &mut len,
             );

--- a/src/cert_context.rs
+++ b/src/cert_context.rs
@@ -139,25 +139,19 @@ impl CertContext {
                 return Err(io::Error::last_os_error());
             }
 
-            let mut buf = vec![0u8; len as usize];
+            let mut buf = vec![0; len as usize];
             let ok = crypt32::CryptBinaryToStringA(
                 (*self.0).pbCertEncoded,
                 (*self.0).cbCertEncoded,
                 CRYPT_STRING_BASE64HEADER,
-                buf.as_mut_ptr() as *mut i8,
+                buf.as_mut_ptr(),
                 &mut len,
             );
             if ok != winapi::TRUE {
                 return Err(io::Error::last_os_error());
             }
 
-            buf.pop();
-            String::from_utf8(buf).map_err(|_| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    "CryptBinaryToStringA() returned unconvertable string",
-                )
-            })
+            Ok(CStr::from_ptr(buf.as_ptr()).to_string_lossy().into_owned())
         }
     }
 


### PR DESCRIPTION
PEM functionality is used by https://github.com/mcgoo/certstoretopem (which could just as well be an example added to this crate if you like.)

DER functionality will be used for https://github.com/alexcrichton/curl-rust/pull/185

cc @sfackler