### PR TITLE
Fix handling of renegotiation requests

### DIFF
--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -722,7 +722,7 @@ impl<S> TlsStream<S>
                         self.enc_in.position() as usize
                     };
                     self.consume_enc_in(nread);
-                    self.needs_read = (self.enc_in.position() == 0) as usize;
+                    self.needs_read = 0;
                     Ok(false)
                 }
                 e => Err(io::Error::from_raw_os_error(e as i32)),


### PR DESCRIPTION
If a renegotiation's been requested, we're responsible for the next
message, so we definitely don't need to read.

Closes #42

@gmbeard can you try out this branch to make sure it works as you'd expect?