### PR TITLE
support use of intermediate certificate authorities

### DIFF
--- a/src/cert_context.rs
+++ b/src/cert_context.rs
@@ -14,6 +14,7 @@ use winapi::um::wincrypt;
 use Inner;
 use ncrypt_key::NcryptKey;
 use crypt_prov::{CryptProv, ProviderType};
+use cert_store::CertStore;
 
 /// A supported hashing algorithm
 pub struct HashAlgorithm(winapi::DWORD, usize);
@@ -296,6 +297,19 @@ impl CertContext {
                 );
             }
             Ok(ValidUses::Oids(oids))
+        }
+    }
+
+    /// For a remote certificate, returns a certificate store containing any intermediate
+    /// certificates provided by the remote sender.
+    pub fn cert_store(&self) -> Option<CertStore> {
+        unsafe {
+            let chain = (*self.0).hCertStore;
+            if chain.is_null() {
+                None
+            } else {
+                Some(CertStore::from_inner(wincrypt::CertDuplicateStore(chain)))
+            }
         }
     }
 

--- a/src/cert_store.rs
+++ b/src/cert_store.rs
@@ -176,7 +176,7 @@ impl CertStore {
     }
 
     /// Returns an iterator over the certificates in this certificate store.
-    pub fn certs(&mut self) -> Certs {
+    pub fn certs(&self) -> Certs {
         Certs { store: self, cur: None }
     }
 
@@ -238,7 +238,7 @@ impl CertStore {
 /// An iterator over the certificates contained in a `CertStore`, returned by
 /// `CertStore::iter`
 pub struct Certs<'a> {
-    store: &'a mut CertStore,
+    store: &'a CertStore,
     cur: Option<CertContext>,
 }
 
@@ -430,7 +430,7 @@ mod test {
     #[test]
     fn pfx_import() {
         let pfx = include_bytes!("../test/identity.p12");
-        let mut store = PfxImportOptions::new()
+        let store = PfxImportOptions::new()
                         .include_extended_properties(true)
                         .password("mypass")
                         .import(pfx)

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -530,7 +530,7 @@ impl<S> TlsStream<S>
             let cert_store = match (cert_context.cert_store(), &self.cert_store) {
                 (Some(ref mut chain_certs), &Some(ref extra_certs)) => {
                     for extra_cert in extra_certs.certs() {
-                        chain_certs.add_cert(&extra_cert, CertAdd::ReplaceExisting)?;
+                        try!(chain_certs.add_cert(&extra_cert, CertAdd::ReplaceExisting));
                     }
                     chain_certs.as_inner()
                 },


### PR DESCRIPTION
It looks like in order to support certificate chains longer than two certificates the `hAdditionalStore` parameter to `CertGetCertificateChain` needs to contain the certificate chain provided by the remote side, available through the `hCertStore` member of the certificate context (remarks on [QueryContextAttributes (General) function](https://msdn.microsoft.com/en-us/library/windows/desktop/aa379326(v=vs.85).aspx)). See [Chromium cert_verify_proc_win.cc](https://chromium.googlesource.com/chromium/src/net/+/6a2d97ad76e85f195ec1edaf9dabbf08b9a8ab1d/cert/cert_verify_proc_win.cc#996).

I'm not sure I've done this correctly because I haven't used the schannel API directly before. This seems to work when the old code didn't.

Was there a reason for iteration of certificates in a store to require mutability of the store? I changed that because I was having trouble merging the local store with the remote store otherwise and it didn't seem right.

Is there a better way to test this than connecting to lh3.googleusercontent.com? That's how I found the problem, but there's no guarantee they won't change their certificates in a way that invalidates the test or even discontinue that domain altogether. I just copied the test above it that connects to google.com.