### PR TITLE
Added Slightly More Docs Regarding Common Trust Locations

### DIFF
--- a/src/cert_store.rs
+++ b/src/cert_store.rs
@@ -102,7 +102,8 @@ pub enum CertAdd {
 impl CertStore {
     /// Opens up the specified key store within the context of the current user.
     ///
-    /// Known valid values for `which` are "Root" and "My".
+    /// Common valid values for `which` are "My", "Root", "Trust", "CA".
+    /// Additonal MSDN docs https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certopenstore#remarks
     pub fn open_current_user(which: &str) -> io::Result<CertStore> {
         unsafe {
             let data = OsStr::new(which)
@@ -122,10 +123,10 @@ impl CertStore {
         }
     }
 
-    /// Opens up the specified key store within the context of the local
-    /// machine.
+    /// Opens up the specified key store within the context of the local machine.
     ///
-    /// Known valid values for `which` are "Root" and "My".
+    /// Common valid values for `which` are "My", "Root", "Trust", "CA".
+    /// Additonal MSDN docs https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certopenstore#remarks
     pub fn open_local_machine(which: &str) -> io::Result<CertStore> {
         unsafe {
             let data = OsStr::new(which)


### PR DESCRIPTION
Wanted to make this a bit more type safe using an `enum` but after reading the MSDN docs it seems that the `pvPara` param is pretty "varied" depending on the context of other params. So as a small improvement just added the 2 other common locations to the docs.