### PR TITLE
Provide access to underlying winapi values at initial set of places

### DIFF
--- a/src/cert_chain.rs
+++ b/src/cert_chain.rs
@@ -8,7 +8,8 @@ use crate::cert_context::CertContext;
 use crate::Inner;
 
 /// A certificate chain context (consisting of multiple chains)
-pub struct CertChainContext(pub wincrypt::PCERT_CHAIN_CONTEXT);
+pub struct CertChainContext(pub(crate) wincrypt::PCERT_CHAIN_CONTEXT);
+inner!(CertChainContext, wincrypt::PCERT_CHAIN_CONTEXT);
 
 unsafe impl Sync for CertChainContext {}
 unsafe impl Send for CertChainContext {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,29 @@ macro_rules! inner {
                 &mut self.0
             }
         }
+
+        impl crate::RawPointer for $t {
+            unsafe fn from_ptr(t: *mut ::std::os::raw::c_void) -> $t {
+                $t(t as _)
+            }
+
+            unsafe fn as_ptr(&self) -> *mut ::std::os::raw::c_void {
+                self.0 as *mut _
+            }
+        }
     }
+}
+
+/// Allows access to the underlying schannel API representation of a wrapped data type
+/// 
+/// Performing actions with internal handles might lead to the violation of internal assumptions 
+/// and therefore is inherently unsafe.
+pub trait RawPointer {
+    /// Constructs an instance of this type from its handle / pointer.
+    unsafe fn from_ptr(t: *mut ::std::os::raw::c_void) -> Self;
+
+    /// Get a raw pointer from the underlying handle / pointer.
+    unsafe fn as_ptr(&self) -> *mut ::std::os::raw::c_void;
 }
 
 pub mod cert_chain;

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -278,14 +278,7 @@ impl CertValidationResult {
 }
 
 impl<S: fmt::Debug + Any> Error for HandshakeError<S> {
-    fn description(&self) -> &str {
-        match *self {
-            HandshakeError::Failure(_) => "failed to perform handshake",
-            HandshakeError::Interrupted(_) => "interrupted performing handshake",
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match *self {
             HandshakeError::Failure(ref e) => Some(e),
             HandshakeError::Interrupted(_) => None,
@@ -295,7 +288,11 @@ impl<S: fmt::Debug + Any> Error for HandshakeError<S> {
 
 impl<S: fmt::Debug + Any> fmt::Display for HandshakeError<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.description())?;
+        let desc = match *self {
+            HandshakeError::Failure(_) => "failed to perform handshake",
+            HandshakeError::Interrupted(_) => "interrupted performing handshake",
+        };
+        write!(f, "{}", desc)?;
         if let Some(e) = self.source() {
            write!(f, ": {}", e)?;
         }


### PR DESCRIPTION
Took a while, but here is an implementation providng access to the underlying handle values, which is decoupled from the winapi crate.

Pinging @Michael-F-Bryan @crusty-dave in case you're still interested in this.

References #58