### PR TITLE
Allow the same SchannelCred to be used for multiple connections to support TLS session ticket resumption

### DIFF
--- a/src/schannel_cred.rs
+++ b/src/schannel_cred.rs
@@ -244,23 +244,17 @@ impl Drop for RawCredHandle {
     }
 }
 
-impl Inner<sspi::CredHandle> for SchannelCred {
-    unsafe fn from_inner(inner: sspi::CredHandle) -> SchannelCred {
-        SchannelCred(Arc::new(RawCredHandle(inner)))
-    }
-
-    fn as_inner(&self) -> sspi::CredHandle {
-        self.0.as_ref().0
-    }
-
-    fn get_mut(&mut self) -> &mut sspi::CredHandle {
-        unimplemented!()
-    }
-}
-
 impl SchannelCred {
     /// Returns a builder.
     pub fn builder() -> Builder {
         Builder::new()
+    }
+
+    unsafe fn from_inner(inner: sspi::CredHandle) -> SchannelCred {
+        SchannelCred(Arc::new(RawCredHandle(inner)))
+    }
+
+    pub(crate) fn as_inner(&self) -> sspi::CredHandle {
+        self.0.as_ref().0
     }
 }

--- a/src/security_context.rs
+++ b/src/security_context.rs
@@ -1,6 +1,6 @@
 use winapi::shared::{sspi, winerror};
 use winapi::shared::minwindef::ULONG;
-use winapi::um::{minschannel};
+use winapi::um::{minschannel, schannel};
 use std::mem;
 use std::ptr;
 use std::io;
@@ -56,7 +56,7 @@ impl SecurityContext {
 
             let mut attributes = 0;
 
-            match sspi::InitializeSecurityContextW(cred.get_mut(),
+            match sspi::InitializeSecurityContextW(&mut cred.as_inner(),
                                                    ptr::null_mut(),
                                                    domain,
                                                    INIT_REQUESTS,
@@ -87,6 +87,12 @@ impl SecurityContext {
             Ok(value)
         } else {
             Err(io::Error::from_raw_os_error(status as i32))
+        }
+    }
+
+    pub fn session_info(&self) -> io::Result<schannel::SecPkgContext_SessionInfo> {
+        unsafe {
+            self.attribute(minschannel::SECPKG_ATTR_SESSION_INFO)
         }
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -342,7 +342,7 @@ fn session_resumption_thread_safety() {
             for _ in 0..10 {
                 let creds = creds_copy.clone();
                 let stream = TcpStream::connect("google.com:443").unwrap();
-                let mut stream = tls_stream::Builder::new()
+                let stream = tls_stream::Builder::new()
                     .domain("google.com")
                     .connect(creds, stream)
                     .unwrap();

--- a/src/test.rs
+++ b/src/test.rs
@@ -289,6 +289,73 @@ fn verify_callback_gives_failed_cert() {
                winerror::CERT_E_UNTRUSTEDROOT as i32);
 }
 
+#[test]
+fn no_session_resumed() {
+    for _ in 0..2 {
+        let creds = SchannelCred::builder().acquire(Direction::Outbound).unwrap();
+        let stream = TcpStream::connect("google.com:443").unwrap();
+        let stream = tls_stream::Builder::new()
+            .domain("google.com")
+            .connect(creds, stream)
+            .unwrap();
+        assert_eq!(stream.session_resumed().unwrap(), Some(false));
+    }
+}
+
+#[test]
+fn basic_session_resumed() {
+    let creds = SchannelCred::builder().acquire(Direction::Outbound).unwrap();
+    let creds_copy = creds.clone();
+
+    let stream = TcpStream::connect("google.com:443").unwrap();
+    let stream = tls_stream::Builder::new()
+        .domain("google.com")
+        .connect(creds_copy, stream)
+        .unwrap();
+    assert_eq!(stream.session_resumed().unwrap(), Some(false));
+
+    let stream = TcpStream::connect("google.com:443").unwrap();
+    let stream = tls_stream::Builder::new()
+        .domain("google.com")
+        .connect(creds, stream)
+        .unwrap();
+    assert_eq!(stream.session_resumed().unwrap(), Some(true));
+}
+
+#[test]
+fn session_resumption_thread_safety() {
+    let creds = SchannelCred::builder().acquire(Direction::Outbound).unwrap();
+
+    // Connect once so that the session ticket is cached.
+    let creds_copy = creds.clone();
+    let stream = TcpStream::connect("google.com:443").unwrap();
+    let stream = tls_stream::Builder::new()
+        .domain("google.com")
+        .connect(creds_copy, stream)
+        .unwrap();
+    assert_eq!(stream.session_resumed().unwrap(), Some(false));
+
+    let mut threads = vec![];
+    for _ in 0..4 {
+        let creds_copy = creds.clone();
+        threads.push(thread::spawn(move || {
+            for _ in 0..10 {
+                let creds = creds_copy.clone();
+                let stream = TcpStream::connect("google.com:443").unwrap();
+                let stream = tls_stream::Builder::new()
+                    .domain("google.com")
+                    .connect(creds, stream)
+                    .unwrap();
+                assert_eq!(stream.session_resumed().unwrap(), Some(true));
+            }
+        }));
+    }
+
+    for thread in threads.into_iter() {
+        thread.join().unwrap()
+    }
+}
+
 const FRIENDLY_NAME: &'static str = "schannel-rs localhost testing cert";
 
 lazy_static! {

--- a/src/test.rs
+++ b/src/test.rs
@@ -298,7 +298,7 @@ fn no_session_resumed() {
             .domain("google.com")
             .connect(creds, stream)
             .unwrap();
-        assert_eq!(stream.session_resumed().unwrap(), Some(false));
+        assert!(!stream.session_resumed().unwrap());
     }
 }
 
@@ -312,14 +312,14 @@ fn basic_session_resumed() {
         .domain("google.com")
         .connect(creds_copy, stream)
         .unwrap();
-    assert_eq!(stream.session_resumed().unwrap(), Some(false));
+    assert!(!stream.session_resumed().unwrap());
 
     let stream = TcpStream::connect("google.com:443").unwrap();
     let stream = tls_stream::Builder::new()
         .domain("google.com")
         .connect(creds, stream)
         .unwrap();
-    assert_eq!(stream.session_resumed().unwrap(), Some(true));
+    assert!(stream.session_resumed().unwrap());
 }
 
 #[test]
@@ -333,7 +333,7 @@ fn session_resumption_thread_safety() {
         .domain("google.com")
         .connect(creds_copy, stream)
         .unwrap();
-    assert_eq!(stream.session_resumed().unwrap(), Some(false));
+    assert!(!stream.session_resumed().unwrap());
 
     let mut threads = vec![];
     for _ in 0..4 {
@@ -342,11 +342,11 @@ fn session_resumption_thread_safety() {
             for _ in 0..10 {
                 let creds = creds_copy.clone();
                 let stream = TcpStream::connect("google.com:443").unwrap();
-                let stream = tls_stream::Builder::new()
+                let mut stream = tls_stream::Builder::new()
                     .domain("google.com")
                     .connect(creds, stream)
                     .unwrap();
-                assert_eq!(stream.session_resumed().unwrap(), Some(true));
+                assert!(stream.session_resumed().unwrap());
             }
         }));
     }

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -353,17 +353,9 @@ impl<S> TlsStream<S>
     }
 
     /// Returns whether or not the session was resumed.
-    ///
-    /// # Remarks
-    /// This is only valid if the TLS handshake is completed, and will return None if called
-    /// before this point.
-    pub fn session_resumed(&self) -> io::Result<Option<bool>> {
-        if let State::Streaming { .. } = self.state {
-            let session_info = self.context.session_info()?;
-            Ok(Some(session_info.dwFlags & schannel::SSL_SESSION_RECONNECT > 0))
-        } else {
-            Ok(None)
-        }
+    pub fn session_resumed(&self) -> io::Result<bool> {
+        let session_info = self.context.session_info()?;
+        Ok(session_info.dwFlags & schannel::SSL_SESSION_RECONNECT > 0)
     }
 
     /// Returns a reference to the buffer of pending data.


### PR DESCRIPTION
Adds an `Arc` within the `SchannelCred`, and slightly reworks the logic that uses it as a result. Not sure what to do about `get_mut()` at this point.

Added tests for the behavior by fetching the `SECPKG_ATTR_SESSION_INFO` attribute off the security context, which has information about whether the session was resumed.

Fixes #66.