### PR TITLE
ALPN support

### DIFF
--- a/src/alpn_list.rs
+++ b/src/alpn_list.rs
@@ -1,0 +1,95 @@
+use std::alloc;
+use std::mem;
+use std::ptr;
+use std::slice;
+use winapi::ctypes;
+use winapi::shared::sspi;
+
+// This is manually calculated here rather than using `size_of::<SEC_APPLICATION_PROTOCOL_LIST>()`,
+// as the latter is 2 bytes too large because it accounts for padding at the end of the struct for
+// alignment requirements, which is irrelevant in actual usage because there is a variable-length
+// array at the end of the struct.
+const SEC_APPLICATION_PROTOCOL_LIST_HEADER_SIZE: usize =
+    mem::size_of::<u32>() + mem::size_of::<ctypes::c_ushort>();
+const SEC_APPLICATION_PROTOCOL_HEADER_SIZE: usize =
+    mem::size_of::<ctypes::c_ulong>() + SEC_APPLICATION_PROTOCOL_LIST_HEADER_SIZE;
+
+pub struct AlpnList {
+    layout: alloc::Layout,
+    memory: ptr::NonNull<u8>,
+}
+
+impl Drop for AlpnList {
+    fn drop(&mut self) {
+        unsafe {
+            // Safety: `self.memory` was allocated with `self.layout` and is non-null.
+            alloc::dealloc(self.memory.as_ptr(), self.layout);
+        }
+    }
+}
+
+impl AlpnList {
+    pub fn new(protos: &[Vec<u8>]) -> Self {
+        // ALPN wire format is each ALPN preceded by its length as a byte.
+        let mut alpn_wire_format = Vec::with_capacity(
+            protos.iter().map(Vec::len).sum::<usize>() + protos.len(),
+        );
+        for alpn in protos {
+            alpn_wire_format.push(alpn.len() as u8);
+            alpn_wire_format.extend(alpn);
+        }
+
+        let size = SEC_APPLICATION_PROTOCOL_HEADER_SIZE + alpn_wire_format.len();
+        let layout = alloc::Layout::from_size_align(
+            size,
+            mem::align_of::<sspi::SEC_APPLICATION_PROTOCOLS>(),
+        ).unwrap();
+
+        unsafe {
+            // Safety: `layout` is guaranteed to have non-zero size.
+            let memory = alloc::alloc(layout);
+            if memory.is_null() {
+                alloc::handle_alloc_error(layout);
+            }
+
+            // Safety: `memory` was created from `layout`.
+            let buf = slice::from_raw_parts_mut(memory, layout.size());
+            let protocols = &mut *(buf.as_mut_ptr() as *mut sspi::SEC_APPLICATION_PROTOCOLS);
+            protocols.ProtocolListsSize =
+                (SEC_APPLICATION_PROTOCOL_LIST_HEADER_SIZE + alpn_wire_format.len()) as ctypes::c_ulong;
+
+            let protocol = &mut *protocols.ProtocolLists.as_mut_ptr();
+            protocol.ProtoNegoExt = sspi::SecApplicationProtocolNegotiationExt_ALPN;
+            protocol.ProtocolListSize = alpn_wire_format.len() as ctypes::c_ushort;
+
+            let protocol_list_offset = protocol.ProtocolList.as_ptr() as usize - buf.as_ptr() as usize;
+            let protocol_list = &mut buf[protocol_list_offset..];
+            protocol_list.copy_from_slice(&alpn_wire_format);
+
+            Self {
+                layout,
+                memory: ptr::NonNull::new(memory).unwrap(),
+            }
+        }
+    }
+}
+
+impl std::ops::Deref for AlpnList {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        unsafe {
+            // Safety: `self.memory` was created from `self.layout`.
+            slice::from_raw_parts(self.memory.as_ptr(), self.layout.size())
+        }
+    }
+}
+
+impl std::ops::DerefMut for AlpnList {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe {
+            // Safety: `self.memory` was created from `self.layout`.
+            slice::from_raw_parts_mut(self.memory.as_ptr(), self.layout.size())
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ extern crate lazy_static;
 
 use std::mem;
 use std::ptr;
+use std::slice;
 use winapi::ctypes;
 use winapi::shared::sspi;
 
@@ -80,6 +81,10 @@ const INIT_REQUESTS: ctypes::c_ulong =
     sspi::ISC_REQ_SEQUENCE_DETECT | sspi::ISC_REQ_MANUAL_CRED_VALIDATION |
     sspi::ISC_REQ_ALLOCATE_MEMORY | sspi::ISC_REQ_STREAM | sspi::ISC_REQ_USE_SUPPLIED_CREDS;
 
+// This is manually calculated here rather than using `size_of::<SEC_APPLICATION_PROTOCOL_LIST>()`,
+// as the latter is 2 bytes too large because it accounts for padding at the end of the struct for
+// alignment requirements, which is irrelevant in actual usage because there is a variable-length
+// array at the end of the struct.
 const SEC_APPLICATION_PROTOCOL_LIST_HEADER_SIZE: usize =
     mem::size_of::<u32>() + mem::size_of::<ctypes::c_ushort>();
 const SEC_APPLICATION_PROTOCOL_HEADER_SIZE: usize =
@@ -114,7 +119,7 @@ unsafe fn secbuf_desc(bufs: &mut [sspi::SecBuffer]) -> sspi::SecBufferDesc {
     }
 }
 
-unsafe fn alpn_list(protos: &[Vec<u8>]) -> Vec<u8> {
+fn alpn_list(protos: &[Vec<u8>]) -> Vec<u8> {
     // ALPN wire format is each ALPN preceded by its length as a byte.
     let mut alpn_wire_format = Vec::with_capacity(
         protos.iter().map(Vec::len).sum::<usize>() + protos.len(),
@@ -125,34 +130,34 @@ unsafe fn alpn_list(protos: &[Vec<u8>]) -> Vec<u8> {
     }
 
     // Make sure that the memory we're using for `sspi::SEC_APPLICATION_PROTOCOLS` matches
-    // alignment requirements.
+    // its current 4-byte alignment requirements.
     let size = SEC_APPLICATION_PROTOCOL_HEADER_SIZE + alpn_wire_format.len();
-    let mut aligned = Vec::<u64>::with_capacity((size - 1) / mem::size_of::<u64>() + 1);
+    let mut aligned = Vec::<u32>::with_capacity((size - 1) / mem::size_of::<u32>() + 1);
     let p = aligned.as_mut_ptr() as *mut u8;
-    let cap = aligned.capacity() * (mem::size_of::<u64>() / mem::size_of::<u8>());
+    let cap = aligned.capacity() * (mem::size_of::<u32>() / mem::size_of::<u8>());
 
     mem::forget(aligned);
 
-    let mut buf = Vec::from_raw_parts(p, 0, cap);
-    buf.resize(size, 0);
+    unsafe {
+        let mut buf = Vec::from_raw_parts(p, 0, cap);
+        buf.resize(size, 0);
 
-    let protocols = buf.as_mut_ptr() as *mut sspi::SEC_APPLICATION_PROTOCOLS;
-    // Make sure that our constant is correctly sized in case of API changes. We could run into OOB
-    // memory accesses if this assertion fires.
-    assert_eq!(
-        &(*(*protocols).ProtocolLists.as_mut_ptr()).ProtocolList as *const _ as usize
-            - protocols as usize,
-        SEC_APPLICATION_PROTOCOL_HEADER_SIZE
-    );
+        let protocols = &mut *(buf.as_mut_ptr() as *mut sspi::SEC_APPLICATION_PROTOCOLS);
+        protocols.ProtocolListsSize =
+            (SEC_APPLICATION_PROTOCOL_LIST_HEADER_SIZE + alpn_wire_format.len()) as ctypes::c_ulong;
 
-    (*protocols).ProtocolListsSize =
-        (SEC_APPLICATION_PROTOCOL_LIST_HEADER_SIZE + alpn_wire_format.len()) as ctypes::c_ulong;
+        let protocol = &mut *protocols.ProtocolLists.as_mut_ptr();
+        protocol.ProtoNegoExt = sspi::SecApplicationProtocolNegotiationExt_ALPN;
+        protocol.ProtocolListSize = alpn_wire_format.len() as ctypes::c_ushort;
 
-    let protocol = (*protocols).ProtocolLists.as_mut_ptr();
-    (*protocol).ProtoNegoExt = sspi::SecApplicationProtocolNegotiationExt_ALPN;
-    (*protocol).ProtocolListSize = alpn_wire_format.len() as ctypes::c_ushort;
+        let protocol_list_start = protocol.ProtocolList.as_mut_ptr();
+        let struct_end = buf.as_ptr().add(size);
+        let protocol_list = slice::from_raw_parts_mut(
+            protocol_list_start,
+            struct_end as usize - protocol_list_start as usize,
+        );
+        protocol_list.copy_from_slice(&alpn_wire_format);
 
-    let protocol_list = (*protocol).ProtocolList.as_mut_ptr();
-    ptr::copy_nonoverlapping(alpn_wire_format.as_ptr(), protocol_list, alpn_wire_format.len());
-    buf
+        buf
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,7 @@ extern crate winapi;
 #[macro_use]
 extern crate lazy_static;
 
-use std::mem;
 use std::ptr;
-use std::slice;
 use winapi::ctypes;
 use winapi::shared::sspi;
 
@@ -65,6 +63,7 @@ pub mod ncrypt_key;
 pub mod schannel_cred;
 pub mod tls_stream;
 
+mod alpn_list;
 mod context_buffer;
 mod security_context;
 
@@ -80,15 +79,6 @@ const INIT_REQUESTS: ctypes::c_ulong =
     sspi::ISC_REQ_CONFIDENTIALITY | sspi::ISC_REQ_INTEGRITY | sspi::ISC_REQ_REPLAY_DETECT |
     sspi::ISC_REQ_SEQUENCE_DETECT | sspi::ISC_REQ_MANUAL_CRED_VALIDATION |
     sspi::ISC_REQ_ALLOCATE_MEMORY | sspi::ISC_REQ_STREAM | sspi::ISC_REQ_USE_SUPPLIED_CREDS;
-
-// This is manually calculated here rather than using `size_of::<SEC_APPLICATION_PROTOCOL_LIST>()`,
-// as the latter is 2 bytes too large because it accounts for padding at the end of the struct for
-// alignment requirements, which is irrelevant in actual usage because there is a variable-length
-// array at the end of the struct.
-const SEC_APPLICATION_PROTOCOL_LIST_HEADER_SIZE: usize =
-    mem::size_of::<u32>() + mem::size_of::<ctypes::c_ushort>();
-const SEC_APPLICATION_PROTOCOL_HEADER_SIZE: usize =
-    mem::size_of::<ctypes::c_ulong>() + SEC_APPLICATION_PROTOCOL_LIST_HEADER_SIZE;
 
 trait Inner<T> {
     unsafe fn from_inner(t: T) -> Self;
@@ -116,48 +106,5 @@ unsafe fn secbuf_desc(bufs: &mut [sspi::SecBuffer]) -> sspi::SecBufferDesc {
         ulVersion: sspi::SECBUFFER_VERSION,
         cBuffers: bufs.len() as ctypes::c_ulong,
         pBuffers: bufs.as_mut_ptr(),
-    }
-}
-
-fn alpn_list(protos: &[Vec<u8>]) -> Vec<u8> {
-    // ALPN wire format is each ALPN preceded by its length as a byte.
-    let mut alpn_wire_format = Vec::with_capacity(
-        protos.iter().map(Vec::len).sum::<usize>() + protos.len(),
-    );
-    for alpn in protos {
-        alpn_wire_format.push(alpn.len() as u8);
-        alpn_wire_format.extend(alpn);
-    }
-
-    // Make sure that the memory we're using for `sspi::SEC_APPLICATION_PROTOCOLS` matches
-    // its current 4-byte alignment requirements.
-    let size = SEC_APPLICATION_PROTOCOL_HEADER_SIZE + alpn_wire_format.len();
-    let mut aligned = Vec::<u32>::with_capacity((size - 1) / mem::size_of::<u32>() + 1);
-    let p = aligned.as_mut_ptr() as *mut u8;
-    let cap = aligned.capacity() * (mem::size_of::<u32>() / mem::size_of::<u8>());
-
-    mem::forget(aligned);
-
-    unsafe {
-        let mut buf = Vec::from_raw_parts(p, 0, cap);
-        buf.resize(size, 0);
-
-        let protocols = &mut *(buf.as_mut_ptr() as *mut sspi::SEC_APPLICATION_PROTOCOLS);
-        protocols.ProtocolListsSize =
-            (SEC_APPLICATION_PROTOCOL_LIST_HEADER_SIZE + alpn_wire_format.len()) as ctypes::c_ulong;
-
-        let protocol = &mut *protocols.ProtocolLists.as_mut_ptr();
-        protocol.ProtoNegoExt = sspi::SecApplicationProtocolNegotiationExt_ALPN;
-        protocol.ProtocolListSize = alpn_wire_format.len() as ctypes::c_ushort;
-
-        let protocol_list_start = protocol.ProtocolList.as_mut_ptr();
-        let struct_end = buf.as_ptr().add(size);
-        let protocol_list = slice::from_raw_parts_mut(
-            protocol_list_start,
-            struct_end as usize - protocol_list_start as usize,
-        );
-        protocol_list.copy_from_slice(&alpn_wire_format);
-
-        buf
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate winapi;
 #[macro_use]
 extern crate lazy_static;
 
+use std::mem;
 use std::ptr;
 use winapi::ctypes;
 use winapi::shared::sspi;
@@ -79,6 +80,11 @@ const INIT_REQUESTS: ctypes::c_ulong =
     sspi::ISC_REQ_SEQUENCE_DETECT | sspi::ISC_REQ_MANUAL_CRED_VALIDATION |
     sspi::ISC_REQ_ALLOCATE_MEMORY | sspi::ISC_REQ_STREAM | sspi::ISC_REQ_USE_SUPPLIED_CREDS;
 
+const SEC_APPLICATION_PROTOCOL_LIST_HEADER_SIZE: usize =
+    mem::size_of::<u32>() + mem::size_of::<ctypes::c_ushort>();
+const SEC_APPLICATION_PROTOCOL_HEADER_SIZE: usize =
+    mem::size_of::<ctypes::c_ulong>() + SEC_APPLICATION_PROTOCOL_LIST_HEADER_SIZE;
+
 trait Inner<T> {
     unsafe fn from_inner(t: T) -> Self;
 
@@ -106,4 +112,47 @@ unsafe fn secbuf_desc(bufs: &mut [sspi::SecBuffer]) -> sspi::SecBufferDesc {
         cBuffers: bufs.len() as ctypes::c_ulong,
         pBuffers: bufs.as_mut_ptr(),
     }
+}
+
+unsafe fn alpn_list(protos: &[Vec<u8>]) -> Vec<u8> {
+    // ALPN wire format is each ALPN preceded by its length as a byte.
+    let mut alpn_wire_format = Vec::with_capacity(
+        protos.iter().map(Vec::len).sum::<usize>() + protos.len(),
+    );
+    for alpn in protos {
+        alpn_wire_format.push(alpn.len() as u8);
+        alpn_wire_format.extend(alpn);
+    }
+
+    // Make sure that the memory we're using for `sspi::SEC_APPLICATION_PROTOCOLS` matches
+    // alignment requirements.
+    let size = SEC_APPLICATION_PROTOCOL_HEADER_SIZE + alpn_wire_format.len();
+    let mut aligned = Vec::<u64>::with_capacity((size - 1) / mem::size_of::<u64>() + 1);
+    let p = aligned.as_mut_ptr() as *mut u8;
+    let cap = aligned.capacity() * (mem::size_of::<u64>() / mem::size_of::<u8>());
+
+    mem::forget(aligned);
+
+    let mut buf = Vec::from_raw_parts(p, 0, cap);
+    buf.resize(size, 0);
+
+    let protocols = buf.as_mut_ptr() as *mut sspi::SEC_APPLICATION_PROTOCOLS;
+    // Make sure that our constant is correctly sized in case of API changes. We could run into OOB
+    // memory accesses if this assertion fires.
+    assert_eq!(
+        &(*(*protocols).ProtocolLists.as_mut_ptr()).ProtocolList as *const _ as usize
+            - protocols as usize,
+        SEC_APPLICATION_PROTOCOL_HEADER_SIZE
+    );
+
+    (*protocols).ProtocolListsSize =
+        (SEC_APPLICATION_PROTOCOL_LIST_HEADER_SIZE + alpn_wire_format.len()) as ctypes::c_ulong;
+
+    let protocol = (*protocols).ProtocolLists.as_mut_ptr();
+    (*protocol).ProtoNegoExt = sspi::SecApplicationProtocolNegotiationExt_ALPN;
+    (*protocol).ProtocolListSize = alpn_wire_format.len() as ctypes::c_ushort;
+
+    let protocol_list = (*protocol).ProtocolList.as_mut_ptr();
+    ptr::copy_nonoverlapping(alpn_wire_format.as_ptr(), protocol_list, alpn_wire_format.len());
+    buf
 }

--- a/src/security_context.rs
+++ b/src/security_context.rs
@@ -5,7 +5,8 @@ use std::mem;
 use std::ptr;
 use std::io;
 
-use crate::{INIT_REQUESTS, Inner, alpn_list, secbuf, secbuf_desc};
+use crate::{INIT_REQUESTS, Inner, secbuf, secbuf_desc};
+use crate::alpn_list::AlpnList;
 use crate::cert_context::CertContext;
 use crate::context_buffer::ContextBuffer;
 
@@ -54,9 +55,8 @@ impl SecurityContext {
 
             let mut inbufs = vec![];
 
-            // Make sure the return value of `alpn_list` is kept alive for the duration of this
-            // function.
-            let mut alpns = requested_application_protocols.as_ref().map(|alpn| alpn_list(alpn));
+            // Make sure `AlpnList` is kept alive for the duration of this function.
+            let mut alpns = requested_application_protocols.as_ref().map(|alpn| AlpnList::new(&alpn));
             if let Some(ref mut alpns) = alpns {
                 inbufs.push(secbuf(sspi::SECBUFFER_APPLICATION_PROTOCOLS,
                                    Some(&mut alpns[..])));

--- a/src/security_context.rs
+++ b/src/security_context.rs
@@ -56,7 +56,7 @@ impl SecurityContext {
 
             // Make sure the return value of `alpn_list` is kept alive for the duration of this
             // function.
-            let mut alpns = requested_application_protocols.as_ref().map(alpn_list);
+            let mut alpns = requested_application_protocols.as_ref().map(|alpn| alpn_list(alpn));
             if let Some(ref mut alpns) = alpns {
                 inbufs.push(secbuf(sspi::SECBUFFER_APPLICATION_PROTOCOLS,
                                    Some(&mut alpns[..])));

--- a/src/security_context.rs
+++ b/src/security_context.rs
@@ -54,13 +54,13 @@ impl SecurityContext {
 
             let mut inbufs = vec![];
 
-            if let &Some(ref alpns) = requested_application_protocols {
-                let mut alpns = alpn_list(&alpns);
-                inbufs.push(secbuf(
-                    sspi::SECBUFFER_APPLICATION_PROTOCOLS,
-                    Some(&mut alpns[..]),
-                ));
-            }
+            // Make sure the return value of `alpn_list` is kept alive for the duration of this
+            // function.
+            let mut alpns = requested_application_protocols.as_ref().map(alpn_list);
+            if let Some(ref mut alpns) = alpns {
+                inbufs.push(secbuf(sspi::SECBUFFER_APPLICATION_PROTOCOLS,
+                                   Some(&mut alpns[..])));
+            };
 
             let mut inbuf_desc = secbuf_desc(&mut inbufs[..]);
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -9,7 +9,8 @@ use winapi::shared::minwindef as winapi;
 use winapi::shared::{basetsd, ntdef, lmcons, winerror};
 use winapi::um::{minwinbase, sysinfoapi, timezoneapi, wincrypt};
 
-use crate::{Inner, alpn_list};
+use crate::Inner;
+use crate::alpn_list::AlpnList;
 use crate::crypt_prov::{AcquireOptions, ProviderType};
 use crate::cert_context::{CertContext, KeySpec, HashAlgorithm};
 use crate::cert_store::{CertStore, Memory, CertAdd};
@@ -846,7 +847,7 @@ fn test_alpn_list() {
     ]
     .concat();
     let full_alpn_list = [&[proto_list.len() as u8, 0, 0, 0] as &[u8], &proto_list].concat();
-    assert_eq!(alpn_list(&vec![b"h2".to_vec()]), full_alpn_list);
+    assert_eq!(&AlpnList::new(&vec![b"h2".to_vec()]) as &[u8], &full_alpn_list as &[u8]);
 
     let raw_proto_alpn_list = b"\x02h2\x08http/1.1";
     // Little-endian bit representation of the expected `SEC_APPLICATION_PROTOCOL_LIST`.
@@ -857,5 +858,5 @@ fn test_alpn_list() {
     ]
     .concat();
     let full_alpn_list = [&[proto_list.len() as u8, 0, 0, 0] as &[u8], &proto_list].concat();
-    assert_eq!(alpn_list(&vec![b"h2".to_vec(), b"http/1.1".to_vec()]), full_alpn_list);
+    assert_eq!(&AlpnList::new(&vec![b"h2".to_vec(), b"http/1.1".to_vec()]) as &[u8], &full_alpn_list as &[u8]);
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -846,9 +846,7 @@ fn test_alpn_list() {
     ]
     .concat();
     let full_alpn_list = [&[proto_list.len() as u8, 0, 0, 0] as &[u8], &proto_list].concat();
-    unsafe {
-        assert_eq!(alpn_list(&vec![b"h2".to_vec()]), full_alpn_list);
-    }
+    assert_eq!(alpn_list(&vec![b"h2".to_vec()]), full_alpn_list);
 
     let raw_proto_alpn_list = b"\x02h2\x08http/1.1";
     // Little-endian bit representation of the expected `SEC_APPLICATION_PROTOCOL_LIST`.
@@ -859,10 +857,5 @@ fn test_alpn_list() {
     ]
     .concat();
     let full_alpn_list = [&[proto_list.len() as u8, 0, 0, 0] as &[u8], &proto_list].concat();
-    unsafe {
-        assert_eq!(
-            alpn_list(&vec![b"h2".to_vec(), b"http/1.1".to_vec()]),
-            full_alpn_list
-        );
-    }
+    assert_eq!(alpn_list(&vec![b"h2".to_vec(), b"http/1.1".to_vec()]), full_alpn_list);
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -9,7 +9,7 @@ use winapi::shared::minwindef as winapi;
 use winapi::shared::{basetsd, ntdef, lmcons, winerror};
 use winapi::um::{minwinbase, sysinfoapi, timezoneapi, wincrypt};
 
-use crate::Inner;
+use crate::{Inner, alpn_list};
 use crate::crypt_prov::{AcquireOptions, ProviderType};
 use crate::cert_context::{CertContext, KeySpec, HashAlgorithm};
 use crate::cert_store::{CertStore, Memory, CertAdd};
@@ -719,4 +719,150 @@ fn split_cert_key() {
     assert_eq!(stream.read(&mut buf).unwrap(), 0);
 
     t.join().unwrap();
+}
+
+#[test]
+fn test_loopback_alpn() {
+    let cert = match localhost_cert() {
+        Some(cert) => cert,
+        None => return,
+    };
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let t = thread::spawn(move || {
+        let stream = TcpStream::connect(&addr).unwrap();
+        let creds = SchannelCred::builder()
+            .acquire(Direction::Outbound)
+            .unwrap();
+        let mut stream = tls_stream::Builder::new()
+            .domain("localhost")
+            .request_application_protocols(&[b"h2"])
+            .connect(creds, stream)
+            .unwrap();
+        assert_eq!(
+            stream
+                .negotiated_application_protocol()
+                .expect("localhost unreachable"),
+            Some(b"h2".to_vec())
+        );
+
+        stream.shutdown().unwrap();
+    });
+
+    let stream = listener.accept().unwrap().0;
+    let creds = SchannelCred::builder()
+        .cert(cert)
+        .acquire(Direction::Inbound)
+        .unwrap();
+    let stream = tls_stream::Builder::new()
+        .request_application_protocols(&[b"h2"])
+        .accept(creds, stream)
+        .unwrap();
+    assert_eq!(
+        stream
+            .negotiated_application_protocol()
+            .expect("localhost unreachable"),
+        Some(b"h2".to_vec())
+    );
+
+    t.join().unwrap();
+}
+
+#[test]
+fn test_loopback_alpn_mismatch() {
+    let cert = match localhost_cert() {
+        Some(cert) => cert,
+        None => return,
+    };
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let t = thread::spawn(move || {
+        let stream = TcpStream::connect(&addr).unwrap();
+        let creds = SchannelCred::builder()
+            .acquire(Direction::Outbound)
+            .unwrap();
+        let mut stream = tls_stream::Builder::new()
+            .domain("localhost")
+            .connect(creds, stream)
+            .unwrap();
+        assert_eq!(
+            stream
+                .negotiated_application_protocol()
+                .expect("localhost unreachable"),
+            None
+        );
+
+        stream.shutdown().unwrap();
+    });
+
+    let stream = listener.accept().unwrap().0;
+    let creds = SchannelCred::builder()
+        .cert(cert)
+        .acquire(Direction::Inbound)
+        .unwrap();
+    let stream = tls_stream::Builder::new()
+        .request_application_protocols(&[b"h2"])
+        .accept(creds, stream)
+        .unwrap();
+    assert_eq!(
+        stream
+            .negotiated_application_protocol()
+            .expect("localhost unreachable"),
+        None
+    );
+
+    t.join().unwrap();
+}
+
+#[test]
+fn test_external_alpn() {
+    let creds = SchannelCred::builder()
+        .acquire(Direction::Outbound)
+        .unwrap();
+    let stream = TcpStream::connect("google.com:443").unwrap();
+    let stream = tls_stream::Builder::new()
+        .request_application_protocols(&[b"h2"])
+        .domain("google.com")
+        .connect(creds, stream)
+        .unwrap();
+    assert_eq!(
+        stream
+            .negotiated_application_protocol()
+            .expect("google.com unreachable"),
+        Some(b"h2".to_vec())
+    );
+}
+
+#[test]
+fn test_alpn_list() {
+    let raw_proto_alpn_list = b"\x02h2";
+    // Little-endian bit representation of the expected `SEC_APPLICATION_PROTOCOL_LIST`.
+    let proto_list = &[
+        // `sspi::SecApplicationProtocolNegotiationExt_ALPN` equals 2.
+        &[2, 0, 0, 0, raw_proto_alpn_list.len() as u8, 0] as &[u8],
+        raw_proto_alpn_list,
+    ]
+    .concat();
+    let full_alpn_list = [&[proto_list.len() as u8, 0, 0, 0] as &[u8], &proto_list].concat();
+    unsafe {
+        assert_eq!(alpn_list(&vec![b"h2".to_vec()]), full_alpn_list);
+    }
+
+    let raw_proto_alpn_list = b"\x02h2\x08http/1.1";
+    // Little-endian bit representation of the expected `SEC_APPLICATION_PROTOCOL_LIST`.
+    let proto_list = &[
+        // `sspi::SecApplicationProtocolNegotiationExt_ALPN` equals 2.
+        &[2, 0, 0, 0, raw_proto_alpn_list.len() as u8, 0] as &[u8],
+        raw_proto_alpn_list,
+    ]
+    .concat();
+    let full_alpn_list = [&[proto_list.len() as u8, 0, 0, 0] as &[u8], &proto_list].concat();
+    unsafe {
+        assert_eq!(
+            alpn_list(&vec![b"h2".to_vec(), b"http/1.1".to_vec()]),
+            full_alpn_list
+        );
+    }
 }

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -12,7 +12,7 @@ use winapi::shared::minwindef as winapi;
 use winapi::shared::{ntdef, sspi, winerror};
 use winapi::um::{self, schannel, wincrypt};
 
-use crate::{INIT_REQUESTS, ACCEPT_REQUESTS, Inner, secbuf, secbuf_desc};
+use crate::{INIT_REQUESTS, ACCEPT_REQUESTS, Inner, alpn_list, secbuf, secbuf_desc};
 use crate::cert_chain::{CertChain, CertChainContext};
 use crate::cert_store::{CertAdd, CertStore};
 use crate::cert_context::CertContext;
@@ -36,6 +36,7 @@ pub struct Builder {
     accept_invalid_hostnames: bool,
     verify_callback: Option<Arc<dyn Fn(CertValidationResult) -> io::Result<()> + Sync + Send>>,
     cert_store: Option<CertStore>,
+    requested_application_protocols: Option<Vec<Vec<u8>>>,
 }
 
 impl Default for Builder {
@@ -46,6 +47,7 @@ impl Default for Builder {
             accept_invalid_hostnames: false,
             verify_callback: None,
             cert_store: None,
+            requested_application_protocols: None,
         }
     }
 }
@@ -108,6 +110,13 @@ impl Builder {
         self
     }
 
+    /// Requests one of a set of application protocols using alpn
+    pub fn request_application_protocols(&mut self, alpns: &[&[u8]]) -> &mut Builder {
+        self.requested_application_protocols =
+            Some(alpns.iter().map(|bytes| bytes.to_vec()).collect::<Vec<_>>());
+        self
+    }
+
     /// Initialize a new TLS session where the stream provided will be
     /// connecting to a remote TLS server.
     ///
@@ -158,7 +167,8 @@ impl Builder {
         };
         let (ctxt, buf) = match SecurityContext::initialize(&mut cred,
                                                             server,
-                                                            domain) {
+                                                            domain,
+                                                            &self.requested_application_protocols) {
             Ok(pair) => pair,
             Err(e) => return Err(HandshakeError::Failure(e)),
         };
@@ -185,6 +195,7 @@ impl Builder {
             enc_in: Cursor::new(Vec::new()),
             out_buf: Cursor::new(buf.map(|b| b.to_owned()).unwrap_or(Vec::new())),
             last_write_len: 0,
+            requested_application_protocols: self.requested_application_protocols.clone(),
         };
 
         MidHandshakeTlsStream {
@@ -226,6 +237,7 @@ pub struct TlsStream<S> {
     out_buf: Cursor<Vec<u8>>,
     /// the (unencrypted) length of the last write call used to track writes
     last_write_len: usize,
+    requested_application_protocols: Option<Vec<Vec<u8>>>,
 }
 
 /// ensures that a TlsStream is always Sync/Send
@@ -352,6 +364,17 @@ impl<S> TlsStream<S>
         self.context.remote_cert()
     }
 
+    /// Returns the negotiated application protocol for this tls stream, if one exists
+    pub fn negotiated_application_protocol(&self) -> io::Result<Option<Vec<u8>>> {
+        let client_proto = self.context.application_protocol()?;
+        if client_proto.ProtoNegoStatus != sspi::SecApplicationProtocolNegotiationStatus_Success
+            || client_proto.ProtoNegoExt != sspi::SecApplicationProtocolNegotiationExt_ALPN
+        {
+            return Ok(None);
+        }
+        Ok(Some(client_proto.ProtocolId[..(client_proto.ProtocolIdSize as usize)].to_vec()))
+    }
+
     /// Returns whether or not the session was resumed.
     pub fn session_resumed(&self) -> io::Result<bool> {
         let session_info = self.context.session_info()?;
@@ -403,10 +426,15 @@ impl<S> TlsStream<S>
     fn step_initialize(&mut self) -> io::Result<()> {
         unsafe {
             let pos = self.enc_in.position() as usize;
-            let mut inbufs = [secbuf(sspi::SECBUFFER_TOKEN,
-                                     Some(&mut self.enc_in.get_mut()[..pos])),
-                              secbuf(sspi::SECBUFFER_EMPTY, None)];
-            let mut inbuf_desc = secbuf_desc(&mut inbufs);
+            let mut inbufs = vec![secbuf(sspi::SECBUFFER_TOKEN,
+                                         Some(&mut self.enc_in.get_mut()[..pos])),
+                                  secbuf(sspi::SECBUFFER_EMPTY, None)];
+            if let Some(ref alpns) = self.requested_application_protocols {
+                let mut alpns = alpn_list(&alpns);
+                inbufs.push(secbuf(sspi::SECBUFFER_APPLICATION_PROTOCOLS,
+                                   Some(&mut alpns[..])));
+            };
+            let mut inbuf_desc = secbuf_desc(&mut inbufs[..]);
 
             let mut outbufs = [secbuf(sspi::SECBUFFER_TOKEN, None),
                                secbuf(sspi::SECBUFFER_ALERT, None),

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -12,7 +12,8 @@ use winapi::shared::minwindef as winapi;
 use winapi::shared::{ntdef, sspi, winerror};
 use winapi::um::{self, schannel, wincrypt};
 
-use crate::{INIT_REQUESTS, ACCEPT_REQUESTS, Inner, alpn_list, secbuf, secbuf_desc};
+use crate::{INIT_REQUESTS, ACCEPT_REQUESTS, Inner, secbuf, secbuf_desc};
+use crate::alpn_list::AlpnList;
 use crate::cert_chain::{CertChain, CertChainContext};
 use crate::cert_store::{CertAdd, CertStore};
 use crate::cert_context::CertContext;
@@ -429,9 +430,8 @@ impl<S> TlsStream<S>
             let mut inbufs = vec![secbuf(sspi::SECBUFFER_TOKEN,
                                          Some(&mut self.enc_in.get_mut()[..pos])),
                                   secbuf(sspi::SECBUFFER_EMPTY, None)];
-            // Make sure the return value of `alpn_list` is kept alive for the duration of this
-            // function.
-            let mut alpns = self.requested_application_protocols.as_ref().map(|alpn| alpn_list(alpn));
+            // Make sure `AlpnList` is kept alive for the duration of this function.
+            let mut alpns = self.requested_application_protocols.as_ref().map(|alpn| AlpnList::new(&alpn));
             if let Some(ref mut alpns) = alpns {
                 inbufs.push(secbuf(sspi::SECBUFFER_APPLICATION_PROTOCOLS,
                                    Some(&mut alpns[..])));

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -372,7 +372,7 @@ impl<S> TlsStream<S>
         {
             return Ok(None);
         }
-        Ok(Some(client_proto.ProtocolId[..(client_proto.ProtocolIdSize as usize)].to_vec()))
+        Ok(Some(client_proto.ProtocolId[..client_proto.ProtocolIdSize as usize].to_vec()))
     }
 
     /// Returns whether or not the session was resumed.
@@ -429,8 +429,10 @@ impl<S> TlsStream<S>
             let mut inbufs = vec![secbuf(sspi::SECBUFFER_TOKEN,
                                          Some(&mut self.enc_in.get_mut()[..pos])),
                                   secbuf(sspi::SECBUFFER_EMPTY, None)];
-            if let Some(ref alpns) = self.requested_application_protocols {
-                let mut alpns = alpn_list(&alpns);
+            // Make sure the return value of `alpn_list` is kept alive for the duration of this
+            // function.
+            let mut alpns = self.requested_application_protocols.as_ref().map(alpn_list);
+            if let Some(ref mut alpns) = alpns {
                 inbufs.push(secbuf(sspi::SECBUFFER_APPLICATION_PROTOCOLS,
                                    Some(&mut alpns[..])));
             };

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -431,7 +431,7 @@ impl<S> TlsStream<S>
                                   secbuf(sspi::SECBUFFER_EMPTY, None)];
             // Make sure the return value of `alpn_list` is kept alive for the duration of this
             // function.
-            let mut alpns = self.requested_application_protocols.as_ref().map(alpn_list);
+            let mut alpns = self.requested_application_protocols.as_ref().map(|alpn| alpn_list(alpn));
             if let Some(ref mut alpns) = alpns {
                 inbufs.push(secbuf(sspi::SECBUFFER_APPLICATION_PROTOCOLS,
                                    Some(&mut alpns[..])));


### PR DESCRIPTION
Implements both client and server-side ALPN negotiation support.

Note that this will only work in Windows 8.1 and above, not exactly sure what happens on Windows 7. https://github.com/curl/curl/issues/840 indicates that `QueryContextAttributes`, at least, will fail.

Adapted from #49.