### PR TITLE
Add EcdhEphem to the list of algorithms

### DIFF
--- a/src/schannel_cred.rs
+++ b/src/schannel_cred.rs
@@ -53,9 +53,8 @@ pub enum Algorithm {
     DssSign = wincrypt::CALG_DSS_SIGN,
     /// Elliptic curve Diffie-Hellman key exchange algorithm.
     Ecdh = wincrypt::CALG_ECDH,
-    // https://github.com/retep998/wincrypt-rs/issues/287
-    // /// Ephemeral elliptic curve Diffie-Hellman key exchange algorithm.
-    // EcdhEphem = wincrypt::CALG_ECDH_EPHEM,
+    /// Ephemeral elliptic curve Diffie-Hellman key exchange algorithm.
+    EcdhEphem = wincrypt::CALG_ECDH_EPHEM,
     /// Elliptic curve digital signature algorithm.
     Ecdsa = wincrypt::CALG_ECDSA,
     /// One way function hashing algorithm.


### PR DESCRIPTION
While https://github.com/retep998/winapi-rs/issues/287 has not been resolved, it looks like `CALG_ECDH_EPHEM` was added in `winapi-rs` 0.3 with https://github.com/retep998/winapi-rs/commit/4bcd5e5ff04fc68a143fb1227eb9d7c97119bacc.