### PR TITLE
Switched from winapi to windows-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,17 @@ documentation = "https://docs.rs/schannel/0.1.19/schannel/"
 repository = "https://github.com/steffengy/schannel-rs"
 readme = "README.md"
 keywords = ["windows", "schannel", "tls", "ssl", "https"]
+edition = "2018"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
 lazy_static = "1.0"
-winapi = { version = "0.3", features = ["lmcons", "minschannel", "securitybaseapi", "schannel", "sspi", "sysinfoapi", "timezoneapi", "winbase", "wincrypt", "winerror"] }
+windows-sys = { version = "0.36", features = [
+    "Win32_Foundation", "Win32_Security_Cryptography",
+    "Win32_Security_Authentication_Identity", "Win32_Security_Credentials",
+    "Win32_System_Memory"] }
+
+[dev-dependencies]
+windows-sys = { version = "0.36", features = ["Win32_System_SystemInformation", "Win32_System_Time"] }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   - TARGET: x86_64-pc-windows-gnu
     VERSION: nightly
   - TARGET: i686-pc-windows-gnu
-    VERSION: 1.31.0
+    VERSION: 1.40.0
   access_token:
     secure: ZxcrtxQXwszRYNN6c1ZIagczEqzmQQZeYHY58izcmF0jdq/cptxJvFUoVxDmnoqj
 install:

--- a/src/cert_context.rs
+++ b/src/cert_context.rs
@@ -1,50 +1,70 @@
-//! Bindings to winapi's `PCCERT_CONTEXT` APIs.
+//! Bindings to Windows `PCCERT_CONTEXT` APIs.
 
-use std::ffi::{CStr, OsString};
+use std::ffi::{c_void, CStr, OsString};
 use std::io;
 use std::mem;
 use std::os::windows::prelude::*;
 use std::ptr;
 use std::slice;
-use winapi::shared::minwindef as winapi;
-use winapi::shared::ntdef;
-use winapi::shared::winerror;
-use winapi::um::wincrypt;
 
-use crate::Inner;
-use crate::ncrypt_key::NcryptKey;
-use crate::crypt_prov::{CryptProv, ProviderType};
+use windows_sys::Win32::Foundation;
+use windows_sys::Win32::Security::Cryptography;
+
 use crate::cert_store::CertStore;
+use crate::crypt_prov::{CryptProv, ProviderType};
+use crate::ncrypt_key::NcryptKey;
+use crate::Inner;
 
 /// A supported hashing algorithm
-pub struct HashAlgorithm(winapi::DWORD, usize);
+pub struct HashAlgorithm(u32, usize);
 
 #[allow(missing_docs)]
 impl HashAlgorithm {
     pub fn md5() -> HashAlgorithm {
-        HashAlgorithm(wincrypt::CALG_MD5, 16)
+        HashAlgorithm(
+            Cryptography::ALG_CLASS_HASH | Cryptography::ALG_TYPE_ANY | Cryptography::ALG_SID_MD5,
+            16,
+        )
     }
 
-    pub fn sha1() -> HashAlgorithm{
-        HashAlgorithm(wincrypt::CALG_SHA1, 20)
+    pub fn sha1() -> HashAlgorithm {
+        HashAlgorithm(
+            Cryptography::ALG_CLASS_HASH | Cryptography::ALG_TYPE_ANY | Cryptography::ALG_SID_SHA1,
+            20,
+        )
     }
 
     pub fn sha256() -> HashAlgorithm {
-        HashAlgorithm(wincrypt::CALG_SHA_256, 32)
+        HashAlgorithm(
+            Cryptography::ALG_CLASS_HASH
+                | Cryptography::ALG_TYPE_ANY
+                | Cryptography::ALG_SID_SHA_256,
+            32,
+        )
     }
 
     pub fn sha384() -> HashAlgorithm {
-        HashAlgorithm(wincrypt::CALG_SHA_384, 48)
+        HashAlgorithm(
+            Cryptography::ALG_CLASS_HASH
+                | Cryptography::ALG_TYPE_ANY
+                | Cryptography::ALG_SID_SHA_384,
+            48,
+        )
     }
 
     pub fn sha512() -> HashAlgorithm {
-        HashAlgorithm(wincrypt::CALG_SHA_512, 64)
+        HashAlgorithm(
+            Cryptography::ALG_CLASS_HASH
+                | Cryptography::ALG_TYPE_ANY
+                | Cryptography::ALG_SID_SHA_512,
+            64,
+        )
     }
 }
 
 /// Wrapper of a winapi certificate, or a `PCCERT_CONTEXT`.
 #[derive(Debug)]
-pub struct CertContext(wincrypt::PCCERT_CONTEXT);
+pub struct CertContext(*const Cryptography::CERT_CONTEXT);
 
 unsafe impl Sync for CertContext {}
 unsafe impl Send for CertContext {}
@@ -52,27 +72,28 @@ unsafe impl Send for CertContext {}
 impl Drop for CertContext {
     fn drop(&mut self) {
         unsafe {
-            wincrypt::CertFreeCertificateContext(self.0);
+            Cryptography::CertFreeCertificateContext(self.0);
         }
     }
 }
 
 impl Clone for CertContext {
     fn clone(&self) -> CertContext {
-        unsafe { CertContext(wincrypt::CertDuplicateCertificateContext(self.0)) }
+        unsafe { CertContext(Cryptography::CertDuplicateCertificateContext(self.0)) }
     }
 }
 
-inner!(CertContext, wincrypt::PCCERT_CONTEXT);
+inner!(CertContext, *const Cryptography::CERT_CONTEXT);
 
 impl CertContext {
     /// Decodes a DER-formatted X509 certificate.
     pub fn new(data: &[u8]) -> io::Result<CertContext> {
         let ret = unsafe {
-            wincrypt::CertCreateCertificateContext(wincrypt::X509_ASN_ENCODING |
-                                                   wincrypt::PKCS_7_ASN_ENCODING,
-                                                   data.as_ptr(),
-                                                   data.len() as winapi::DWORD)
+            Cryptography::CertCreateCertificateContext(
+                Cryptography::X509_ASN_ENCODING | Cryptography::PKCS_7_ASN_ENCODING,
+                data.as_ptr(),
+                data.len() as u32,
+            )
         };
         if ret.is_null() {
             Err(io::Error::last_os_error())
@@ -82,34 +103,40 @@ impl CertContext {
     }
 
     /// Get certificate in binary DER form
-    pub fn to_der<'a>(&'a self) -> &'a [u8] {
+    pub fn to_der(&self) -> &[u8] {
         self.get_encoded_bytes()
     }
 
     /// Certificate subject public key info
     pub fn subject_public_key_info_der(&self) -> io::Result<Vec<u8>> {
         unsafe {
-            let mut len:u32 = 0;
-            let ok = wincrypt::CryptEncodeObjectEx(wincrypt::X509_ASN_ENCODING,
-                                                   wincrypt::CERT_INFO_SUBJECT_PUBLIC_KEY_INFO_FLAG as *const u32 as *const _,
-                                                   &(*(*self.0).pCertInfo).SubjectPublicKeyInfo as *const wincrypt::CERT_PUBLIC_KEY_INFO as _,
-                                                   0,
-                                                   ptr::null_mut(),
-                                                   ptr::null_mut(),
-                                                   &mut len as *mut _);
-            if ok != winapi::TRUE {
+            let mut len: u32 = 0;
+            let ok = Cryptography::CryptEncodeObjectEx(
+                Cryptography::X509_ASN_ENCODING,
+                Cryptography::CERT_INFO_SUBJECT_PUBLIC_KEY_INFO_FLAG as *const u8,
+                &(*(*self.0).pCertInfo).SubjectPublicKeyInfo
+                    as *const Cryptography::CERT_PUBLIC_KEY_INFO as _,
+                Cryptography::CRYPT_ENCODE_OBJECT_FLAGS::default(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                &mut len,
+            );
+            if ok == 0 {
                 return Err(io::Error::last_os_error());
             }
             if len > 0 {
                 let mut buf = vec![0; len as usize];
-                let ok = wincrypt::CryptEncodeObjectEx(wincrypt::X509_ASN_ENCODING,
-                                                  wincrypt::CERT_INFO_SUBJECT_PUBLIC_KEY_INFO_FLAG as *const u32 as *const _,
-                                                  &(*(*self.0).pCertInfo).SubjectPublicKeyInfo as *const wincrypt::CERT_PUBLIC_KEY_INFO as _,
-                                                  0,
-                                                  ptr::null_mut(),
-                                                  buf.as_mut_ptr() as _,
-                                                  &mut len as *mut _);
-                if ok != winapi::TRUE {
+                let ok = Cryptography::CryptEncodeObjectEx(
+                    Cryptography::X509_ASN_ENCODING,
+                    Cryptography::CERT_INFO_SUBJECT_PUBLIC_KEY_INFO_FLAG as *const u32 as *const _,
+                    &(*(*self.0).pCertInfo).SubjectPublicKeyInfo
+                        as *const Cryptography::CERT_PUBLIC_KEY_INFO as _,
+                    Cryptography::CRYPT_ENCODE_OBJECT_FLAGS::default(),
+                    ptr::null_mut(),
+                    buf.as_mut_ptr() as _,
+                    &mut len,
+                );
+                if ok == 0 {
                     return Err(io::Error::last_os_error());
                 }
                 return Ok(buf);
@@ -121,29 +148,33 @@ impl CertContext {
     /// Decodes a PEM-formatted X509 certificate.
     pub fn from_pem(pem: &str) -> io::Result<CertContext> {
         unsafe {
-            assert!(pem.len() <= winapi::DWORD::max_value() as usize);
+            assert!(pem.len() <= u32::max_value() as usize);
 
             let mut len = 0;
-            let ok = wincrypt::CryptStringToBinaryA(pem.as_ptr() as ntdef::LPCSTR,
-                                                    pem.len() as winapi::DWORD,
-                                                    wincrypt::CRYPT_STRING_BASE64HEADER,
-                                                    ptr::null_mut(),
-                                                    &mut len,
-                                                    ptr::null_mut(),
-                                                    ptr::null_mut());
-            if ok != winapi::TRUE {
+            let ok = Cryptography::CryptStringToBinaryA(
+                pem.as_ptr(),
+                pem.len() as u32,
+                Cryptography::CRYPT_STRING_BASE64HEADER,
+                ptr::null_mut(),
+                &mut len,
+                ptr::null_mut(),
+                ptr::null_mut(),
+            );
+            if ok == 0 {
                 return Err(io::Error::last_os_error());
             }
 
             let mut buf = vec![0; len as usize];
-            let ok = wincrypt::CryptStringToBinaryA(pem.as_ptr() as ntdef::LPCSTR,
-                                                    pem.len() as winapi::DWORD,
-                                                    wincrypt::CRYPT_STRING_BASE64HEADER,
-                                                    buf.as_mut_ptr(),
-                                                    &mut len,
-                                                    ptr::null_mut(),
-                                                    ptr::null_mut());
-            if ok != winapi::TRUE {
+            let ok = Cryptography::CryptStringToBinaryA(
+                pem.as_ptr(),
+                pem.len() as u32,
+                Cryptography::CRYPT_STRING_BASE64HEADER,
+                buf.as_mut_ptr(),
+                &mut len,
+                ptr::null_mut(),
+                ptr::null_mut(),
+            );
+            if ok == 0 {
                 return Err(io::Error::last_os_error());
             }
 
@@ -155,30 +186,32 @@ impl CertContext {
     pub fn to_pem(&self) -> io::Result<String> {
         unsafe {
             let mut len = 0;
-            let ok = wincrypt::CryptBinaryToStringA(
+            let ok = Cryptography::CryptBinaryToStringA(
                 (*self.0).pbCertEncoded,
                 (*self.0).cbCertEncoded,
-                wincrypt::CRYPT_STRING_BASE64HEADER,
+                Cryptography::CRYPT_STRING_BASE64HEADER,
                 ptr::null_mut(),
                 &mut len,
             );
-            if ok != winapi::TRUE {
+            if ok == 0 {
                 return Err(io::Error::last_os_error());
             }
 
             let mut buf = vec![0; len as usize];
-            let ok = wincrypt::CryptBinaryToStringA(
+            let ok = Cryptography::CryptBinaryToStringA(
                 (*self.0).pbCertEncoded,
                 (*self.0).cbCertEncoded,
-                wincrypt::CRYPT_STRING_BASE64HEADER,
+                Cryptography::CRYPT_STRING_BASE64HEADER,
                 buf.as_mut_ptr(),
                 &mut len,
             );
-            if ok != winapi::TRUE {
+            if ok == 0 {
                 return Err(io::Error::last_os_error());
             }
 
-            Ok(CStr::from_ptr(buf.as_ptr()).to_string_lossy().into_owned())
+            Ok(CStr::from_ptr(buf.as_ptr() as *const _)
+                .to_string_lossy()
+                .into_owned())
         }
     }
 
@@ -186,17 +219,19 @@ impl CertContext {
     pub fn fingerprint(&self, alg: HashAlgorithm) -> io::Result<Vec<u8>> {
         unsafe {
             let mut buf = vec![0u8; alg.1];
-            let mut len = buf.len() as winapi::DWORD;
+            let mut len = buf.len() as u32;
 
-            let ret = wincrypt::CryptHashCertificate(0,
-                                                     alg.0,
-                                                     0,
-                                                     (*self.0).pbCertEncoded,
-                                                     (*self.0).cbCertEncoded,
-                                                     buf.as_mut_ptr(),
-                                                     &mut len);
+            let ret = Cryptography::CryptHashCertificate(
+                Cryptography::HCRYPTPROV_LEGACY::default(),
+                alg.0,
+                0,
+                (*self.0).pbCertEncoded,
+                (*self.0).cbCertEncoded,
+                buf.as_mut_ptr(),
+                &mut len,
+            );
 
-            if ret != winapi::TRUE {
+            if ret == 0 {
                 return Err(io::Error::last_os_error());
             }
             Ok(buf)
@@ -226,40 +261,41 @@ impl CertContext {
     /// * `RSA/SHA256`
     /// * `ECDSA/SHA256`
     pub fn sign_hash_algorithms(&self) -> io::Result<String> {
-        self.get_string(wincrypt::CERT_SIGN_HASH_CNG_ALG_PROP_ID)
+        self.get_string(Cryptography::CERT_SIGN_HASH_CNG_ALG_PROP_ID)
     }
 
     /// Returns the signature hash.
     pub fn signature_hash(&self) -> io::Result<Vec<u8>> {
-        self.get_bytes(wincrypt::CERT_SIGNATURE_HASH_PROP_ID)
+        self.get_bytes(Cryptography::CERT_SIGNATURE_HASH_PROP_ID)
     }
 
     /// Returns the property displayed by the certificate UI. This property
     /// allows the user to describe the certificate's use.
     pub fn description(&self) -> io::Result<Vec<u8>> {
-        self.get_bytes(wincrypt::CERT_DESCRIPTION_PROP_ID)
+        self.get_bytes(Cryptography::CERT_DESCRIPTION_PROP_ID)
     }
 
     /// Returns a string that contains the display name for the certificate.
     pub fn friendly_name(&self) -> io::Result<String> {
-        self.get_string(wincrypt::CERT_FRIENDLY_NAME_PROP_ID)
+        self.get_string(Cryptography::CERT_FRIENDLY_NAME_PROP_ID)
     }
 
     /// Configures the string that contains the display name for this
     /// certificate.
     pub fn set_friendly_name(&self, name: &str) -> io::Result<()> {
-        self.set_string(wincrypt::CERT_FRIENDLY_NAME_PROP_ID, name)
+        self.set_string(Cryptography::CERT_FRIENDLY_NAME_PROP_ID, name)
     }
 
     /// Verifies the time validity of this certificate relative to the system's
     /// current time.
     pub fn is_time_valid(&self) -> io::Result<bool> {
-        let ret = unsafe { wincrypt::CertVerifyTimeValidity(ptr::null_mut(), (*self.0).pCertInfo) };
+        let ret =
+            unsafe { Cryptography::CertVerifyTimeValidity(ptr::null_mut(), (*self.0).pCertInfo) };
         Ok(ret == 0)
     }
 
     /// Returns a builder used to acquire the private key corresponding to this certificate.
-    pub fn private_key<'a>(&'a self) -> AcquirePrivateKeyOptions<'a> {
+    pub fn private_key(&self) -> AcquirePrivateKeyOptions {
         AcquirePrivateKeyOptions {
             cert: self,
             flags: 0,
@@ -269,9 +305,9 @@ impl CertContext {
     /// Deletes this certificate from its certificate store.
     pub fn delete(self) -> io::Result<()> {
         unsafe {
-            let ret = wincrypt::CertDeleteCertificateFromStore(self.0);
+            let ret = Cryptography::CertDeleteCertificateFromStore(self.0);
             mem::forget(self);
-            if ret == winapi::TRUE {
+            if ret != 0 {
                 Ok(())
             } else {
                 Err(io::Error::last_os_error())
@@ -280,7 +316,7 @@ impl CertContext {
     }
 
     /// Returns a builder used to set the private key associated with this certificate.
-    pub fn set_key_prov_info<'a>(&'a self) -> SetKeyProvInfo<'a> {
+    pub fn set_key_prov_info(&self) -> SetKeyProvInfo {
         SetKeyProvInfo {
             cert: self,
             container: None,
@@ -295,17 +331,19 @@ impl CertContext {
     pub fn valid_uses(&self) -> io::Result<ValidUses> {
         unsafe {
             let mut buf_len = 0;
-            let ok = wincrypt::CertGetEnhancedKeyUsage(self.0, 0, ptr::null_mut(), &mut buf_len);
+            let ok =
+                Cryptography::CertGetEnhancedKeyUsage(self.0, 0, ptr::null_mut(), &mut buf_len);
 
-            if ok != winapi::TRUE {
+            if ok == 0 {
                 return Err(io::Error::last_os_error());
             }
 
             let mut buf = vec![0u8; buf_len as usize];
-            let cert_enhkey_usage = buf.as_mut_ptr() as *mut wincrypt::CERT_ENHKEY_USAGE;
+            let cert_enhkey_usage = buf.as_mut_ptr() as *mut Cryptography::CTL_USAGE;
 
-            let ok = wincrypt::CertGetEnhancedKeyUsage(self.0, 0, cert_enhkey_usage, &mut buf_len);
-            if ok != winapi::TRUE {
+            let ok =
+                Cryptography::CertGetEnhancedKeyUsage(self.0, 0, cert_enhkey_usage, &mut buf_len);
+            if ok == 0 {
                 return Err(io::Error::last_os_error());
             }
 
@@ -313,8 +351,8 @@ impl CertContext {
             if use_cnt == 0 {
                 let last_error = io::Error::last_os_error();
                 match last_error.raw_os_error() {
-                    Some(winerror::CRYPT_E_NOT_FOUND) => return Ok(ValidUses::All),
-                    Some(0) => (),
+                    Some(Foundation::CRYPT_E_NOT_FOUND) => return Ok(ValidUses::All),
+                    Some(Foundation::S_OK) => (),
                     _ => return Err(last_error),
                 };
             }
@@ -323,7 +361,7 @@ impl CertContext {
             for i in 0..use_cnt {
                 let oid_ptr = (*cert_enhkey_usage).rgpszUsageIdentifier;
                 oids.push(
-                    CStr::from_ptr(*(oid_ptr.offset(i as isize)))
+                    CStr::from_ptr(*(oid_ptr.offset(i as isize)) as *const _)
                         .to_string_lossy()
                         .into_owned(),
                 );
@@ -340,45 +378,57 @@ impl CertContext {
             if chain.is_null() {
                 None
             } else {
-                Some(CertStore::from_inner(wincrypt::CertDuplicateStore(chain)))
+                Some(CertStore::from_inner(Cryptography::CertDuplicateStore(
+                    chain,
+                )))
             }
         }
     }
 
-    fn get_encoded_bytes<'a>(&'a self) -> &'a [u8] {
+    fn get_encoded_bytes(&self) -> &[u8] {
         unsafe {
             let cert_ctx = *self.0;
             slice::from_raw_parts(cert_ctx.pbCertEncoded, cert_ctx.cbCertEncoded as usize)
         }
     }
 
-    fn get_bytes(&self, prop: winapi::DWORD) -> io::Result<Vec<u8>> {
+    fn get_bytes(&self, prop: u32) -> io::Result<Vec<u8>> {
         unsafe {
             let mut len = 0;
-            let ret =
-                wincrypt::CertGetCertificateContextProperty(self.0, prop, ptr::null_mut(), &mut len);
-            if ret != winapi::TRUE {
+            let ret = Cryptography::CertGetCertificateContextProperty(
+                self.0,
+                prop,
+                ptr::null_mut(),
+                &mut len,
+            );
+            if ret == 0 {
                 return Err(io::Error::last_os_error());
             }
 
             let mut buf = vec![0u8; len as usize];
-            let ret = wincrypt::CertGetCertificateContextProperty(self.0,
-                                                                  prop,
-                                                                  buf.as_mut_ptr() as winapi::LPVOID,
-                                                                  &mut len);
-            if ret != winapi::TRUE {
+            let ret = Cryptography::CertGetCertificateContextProperty(
+                self.0,
+                prop,
+                buf.as_mut_ptr() as *mut c_void,
+                &mut len,
+            );
+            if ret == 0 {
                 return Err(io::Error::last_os_error());
             }
             Ok(buf)
         }
     }
 
-    fn get_string(&self, prop: winapi::DWORD) -> io::Result<String> {
+    fn get_string(&self, prop: u32) -> io::Result<String> {
         unsafe {
             let mut len = 0;
-            let ret =
-                wincrypt::CertGetCertificateContextProperty(self.0, prop, ptr::null_mut(), &mut len);
-            if ret != winapi::TRUE {
+            let ret = Cryptography::CertGetCertificateContextProperty(
+                self.0,
+                prop,
+                ptr::null_mut(),
+                &mut len,
+            );
+            if ret == 0 {
                 return Err(io::Error::last_os_error());
             }
 
@@ -386,11 +436,13 @@ impl CertContext {
             // u16 pairs which are 2 bytes each.
             let amt = (len / 2) as usize;
             let mut buf = vec![0u16; amt];
-            let ret = wincrypt::CertGetCertificateContextProperty(self.0,
-                                                                  prop,
-                                                                  buf.as_mut_ptr() as winapi::LPVOID,
-                                                                  &mut len);
-            if ret != winapi::TRUE {
+            let ret = Cryptography::CertGetCertificateContextProperty(
+                self.0,
+                prop,
+                buf.as_mut_ptr() as *mut c_void,
+                &mut len,
+            );
+            if ret == 0 {
                 return Err(io::Error::last_os_error());
             }
 
@@ -399,18 +451,20 @@ impl CertContext {
         }
     }
 
-    fn set_string(&self, prop: winapi::DWORD, s: &str) -> io::Result<()> {
+    fn set_string(&self, prop: u32, s: &str) -> io::Result<()> {
         unsafe {
             let data = s.encode_utf16().chain(Some(0)).collect::<Vec<_>>();
-            let data = wincrypt::CRYPT_DATA_BLOB {
-                cbData: (data.len() * 2) as winapi::DWORD,
+            let data = Cryptography::CRYPTOAPI_BLOB {
+                cbData: (data.len() * 2) as u32,
                 pbData: data.as_ptr() as *mut _,
             };
-            let ret = wincrypt::CertSetCertificateContextProperty(self.0,
-                                                                  prop,
-                                                                  0,
-                                                                  &data as *const _ as *const _);
-            if ret != winapi::TRUE {
+            let ret = Cryptography::CertSetCertificateContextProperty(
+                self.0,
+                prop,
+                0,
+                &data as *const _ as *const _,
+            );
+            if ret == 0 {
                 Err(io::Error::last_os_error())
             } else {
                 Ok(())
@@ -428,23 +482,23 @@ impl PartialEq for CertContext {
 /// A builder type for certificate private key lookup.
 pub struct AcquirePrivateKeyOptions<'a> {
     cert: &'a CertContext,
-    flags: winapi::DWORD,
+    flags: u32,
 }
 
 impl<'a> AcquirePrivateKeyOptions<'a> {
     /// If set, the certificate's public key will be compared with the private key to ensure a
     /// match.
     pub fn compare_key(&mut self, compare_key: bool) -> &mut AcquirePrivateKeyOptions<'a> {
-        self.flag(wincrypt::CRYPT_ACQUIRE_COMPARE_KEY_FLAG, compare_key)
+        self.flag(Cryptography::CRYPT_ACQUIRE_COMPARE_KEY_FLAG, compare_key)
     }
 
     /// If set, the lookup will not display any user interface, even if that causes the lookup to
     /// fail.
     pub fn silent(&mut self, silent: bool) -> &mut AcquirePrivateKeyOptions<'a> {
-        self.flag(wincrypt::CRYPT_ACQUIRE_SILENT_FLAG, silent)
+        self.flag(Cryptography::CRYPT_ACQUIRE_SILENT_FLAG, silent)
     }
 
-    fn flag(&mut self, flag: winapi::DWORD, set: bool) -> &mut AcquirePrivateKeyOptions<'a> {
+    fn flag(&mut self, flag: u32, set: bool) -> &mut AcquirePrivateKeyOptions<'a> {
         if set {
             self.flags |= flag;
         } else {
@@ -456,21 +510,23 @@ impl<'a> AcquirePrivateKeyOptions<'a> {
     /// Acquires the private key handle.
     pub fn acquire(&self) -> io::Result<PrivateKey> {
         unsafe {
-            let flags = self.flags | wincrypt::CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG;
-            let mut handle = 0;
-            let mut spec = 0;
-            let mut free = winapi::FALSE;
-            let res = wincrypt::CryptAcquireCertificatePrivateKey(self.cert.0,
-                                                                  flags,
-                                                                  ptr::null_mut(),
-                                                                  &mut handle,
-                                                                  &mut spec,
-                                                                  &mut free);
-            if res != winapi::TRUE {
+            let flags = self.flags | Cryptography::CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG;
+            let mut handle = Cryptography::HCRYPTPROV_OR_NCRYPT_KEY_HANDLE::default();
+            let mut spec = Cryptography::CERT_KEY_SPEC::default();
+            let mut free = Foundation::BOOL::default();
+            let res = Cryptography::CryptAcquireCertificatePrivateKey(
+                self.cert.0,
+                flags,
+                ptr::null_mut(),
+                &mut handle,
+                &mut spec,
+                &mut free,
+            );
+            if res == 0 {
                 return Err(io::Error::last_os_error());
             }
-            assert!(free == winapi::TRUE);
-            if spec & wincrypt::CERT_NCRYPT_KEY_SPEC != 0 {
+            assert_ne!(free, 0);
+            if spec & Cryptography::CERT_NCRYPT_KEY_SPEC != 0 {
                 Ok(PrivateKey::NcryptKey(NcryptKey::from_inner(handle)))
             } else {
                 Ok(PrivateKey::CryptProv(CryptProv::from_inner(handle)))
@@ -492,9 +548,9 @@ pub struct SetKeyProvInfo<'a> {
     cert: &'a CertContext,
     container: Option<Vec<u16>>,
     provider: Option<Vec<u16>>,
-    type_: winapi::DWORD,
-    flags: winapi::DWORD,
-    key_spec: winapi::DWORD,
+    type_: u32,
+    flags: u32,
+    key_spec: u32,
 }
 
 impl<'a> SetKeyProvInfo<'a> {
@@ -528,21 +584,21 @@ impl<'a> SetKeyProvInfo<'a> {
     /// If set, the handle to the key provider can be kept open for subsequent
     /// calls to cryptographic functions.
     pub fn keep_open(&mut self, keep_open: bool) -> &mut SetKeyProvInfo<'a> {
-        self.flag(wincrypt::CERT_SET_KEY_PROV_HANDLE_PROP_ID, keep_open)
+        self.flag(Cryptography::CERT_SET_KEY_PROV_HANDLE_PROP_ID, keep_open)
     }
 
     /// If set, the key container contains machine keys.
     pub fn machine_keyset(&mut self, machine_keyset: bool) -> &mut SetKeyProvInfo<'a> {
-        self.flag(wincrypt::CRYPT_MACHINE_KEYSET, machine_keyset)
+        self.flag(Cryptography::CRYPT_MACHINE_KEYSET, machine_keyset)
     }
 
     /// If set, the key container will attempt to open keys without any user
     /// interface prompts.
     pub fn silent(&mut self, silent: bool) -> &mut SetKeyProvInfo<'a> {
-        self.flag(wincrypt::CRYPT_SILENT, silent)
+        self.flag(Cryptography::CRYPT_SILENT, silent)
     }
 
-    fn flag(&mut self, flag: winapi::DWORD, on: bool) -> &mut SetKeyProvInfo<'a> {
+    fn flag(&mut self, flag: u32, on: bool) -> &mut SetKeyProvInfo<'a> {
         if on {
             self.flags |= flag;
         } else {
@@ -560,10 +616,18 @@ impl<'a> SetKeyProvInfo<'a> {
     /// Sets the private key for this certificate.
     pub fn set(&mut self) -> io::Result<()> {
         unsafe {
-            let container = self.container.as_ref().map(|s| s.as_ptr()).unwrap_or(ptr::null());
-            let provider = self.provider.as_ref().map(|s| s.as_ptr()).unwrap_or(ptr::null());
+            let container = self
+                .container
+                .as_ref()
+                .map(|s| s.as_ptr())
+                .unwrap_or(ptr::null());
+            let provider = self
+                .provider
+                .as_ref()
+                .map(|s| s.as_ptr())
+                .unwrap_or(ptr::null());
 
-            let info = wincrypt::CRYPT_KEY_PROV_INFO {
+            let info = Cryptography::CRYPT_KEY_PROV_INFO {
                 pwszContainerName: container as *mut _,
                 pwszProvName: provider as *mut _,
                 dwProvType: self.type_,
@@ -573,12 +637,13 @@ impl<'a> SetKeyProvInfo<'a> {
                 dwKeySpec: self.key_spec,
             };
 
-            let res =
-                wincrypt::CertSetCertificateContextProperty(self.cert.0,
-                                                            wincrypt::CERT_KEY_PROV_INFO_PROP_ID,
-                                                            0,
-                                                            &info as *const _ as *const _);
-            if res == winapi::TRUE {
+            let res = Cryptography::CertSetCertificateContextProperty(
+                self.cert.0,
+                Cryptography::CERT_KEY_PROV_INFO_PROP_ID,
+                0,
+                &info as *const _ as *const _,
+            );
+            if res != 0 {
                 Ok(())
             } else {
                 Err(io::Error::last_os_error())
@@ -589,17 +654,17 @@ impl<'a> SetKeyProvInfo<'a> {
 
 /// The specification of a private key.
 #[derive(Copy, Clone)]
-pub struct KeySpec(winapi::DWORD);
+pub struct KeySpec(u32);
 
 impl KeySpec {
     /// A key used to encrypt/decrypt session keys.
     pub fn key_exchange() -> KeySpec {
-        KeySpec(wincrypt::AT_KEYEXCHANGE)
+        KeySpec(Cryptography::AT_KEYEXCHANGE)
     }
 
     /// A key used to create and verify digital signatures.
     pub fn signature() -> KeySpec {
-        KeySpec(wincrypt::AT_SIGNATURE)
+        KeySpec(Cryptography::AT_SIGNATURE)
     }
 }
 
@@ -638,10 +703,10 @@ mod test {
     #[test]
     fn certcontext_to_pem() {
         let der = include_bytes!("../test/cert.der");
-        let pem1 = include_str!("../test/cert.pem").replace("\r", "");
+        let pem1 = include_str!("../test/cert.pem").replace('\r', "");
 
         let der = CertContext::new(der).unwrap();
-        let pem2 = CertContext::to_pem(&der).unwrap().replace("\r", "");
+        let pem2 = CertContext::to_pem(&der).unwrap().replace('\r', "");
         assert_eq!(pem1, pem2);
     }
 
@@ -654,19 +719,24 @@ mod test {
         let pem = CertContext::from_pem(pem).unwrap();
 
         let hash = der.fingerprint(HashAlgorithm::sha1()).unwrap();
-        assert_eq!(hash, vec![‎
-            0x59, 0x17, 0x2D, 0x93, 0x13, 0xE8, 0x44, 0x59, 0xBC, 0xFF,
-            0x27, 0xF9, 0x67, 0xE7, 0x9E, 0x6E, 0x92, 0x17, 0xE5, 0x84
-        ]);
+        assert_eq!(
+            hash,
+            vec![
+                0x59, 0x17, 0x2D, 0x93, 0x13, 0xE8, 0x44, 0x59, 0xBC, 0xFF, 0x27, 0xF9, 0x67, 0xE7,
+                0x9E, 0x6E, 0x92, 0x17, 0xE5, 0x84
+            ]
+        );
         assert_eq!(hash, pem.fingerprint(HashAlgorithm::sha1()).unwrap());
 
         let hash = der.fingerprint(HashAlgorithm::sha256()).unwrap();
-        assert_eq!(hash, vec![
-            0x47, 0x12, 0xB9, 0x39, 0xFB, 0xCB, 0x42, 0xA6, 0xB5, 0x10,
-            0x1B, 0x42, 0x13, 0x9A, 0x25, 0xB1, 0x4F, 0x81, 0xB4, 0x18,
-            0xFA, 0xCA, 0xBD, 0x37, 0x87, 0x46, 0xF1, 0x2F, 0x85, 0xCC,
-            0x65, 0x44
-        ]);
+        assert_eq!(
+            hash,
+            vec![
+                0x47, 0x12, 0xB9, 0x39, 0xFB, 0xCB, 0x42, 0xA6, 0xB5, 0x10, 0x1B, 0x42, 0x13, 0x9A,
+                0x25, 0xB1, 0x4F, 0x81, 0xB4, 0x18, 0xFA, 0xCA, 0xBD, 0x37, 0x87, 0x46, 0xF1, 0x2F,
+                0x85, 0xCC, 0x65, 0x44
+            ]
+        );
         assert_eq!(hash, pem.fingerprint(HashAlgorithm::sha256()).unwrap());
     }
 }

--- a/src/cert_store.rs
+++ b/src/cert_store.rs
@@ -7,42 +7,40 @@ use std::io;
 use std::mem;
 use std::os::windows::prelude::*;
 use std::ptr;
-use winapi::shared::minwindef as winapi;
-use winapi::shared::ntdef;
-use winapi::um::wincrypt;
+
+use windows_sys::Win32::Security::Cryptography;
 
 use crate::cert_context::CertContext;
 use crate::ctl_context::CtlContext;
-
 use crate::Inner;
 
 /// Representation of certificate store on Windows, wrapping a `HCERTSTORE`.
-pub struct CertStore(wincrypt::HCERTSTORE);
+pub struct CertStore(Cryptography::HCERTSTORE);
 
 unsafe impl Sync for CertStore {}
 unsafe impl Send for CertStore {}
 
 impl fmt::Debug for CertStore {
-	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-		fmt.debug_struct("CertStore").finish()
-	}
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("CertStore").finish()
+    }
 }
 
 impl Drop for CertStore {
     fn drop(&mut self) {
         unsafe {
-            wincrypt::CertCloseStore(self.0, 0);
+            Cryptography::CertCloseStore(self.0, 0);
         }
     }
 }
 
 impl Clone for CertStore {
     fn clone(&self) -> CertStore {
-        unsafe { CertStore(wincrypt::CertDuplicateStore(self.0)) }
+        unsafe { CertStore(Cryptography::CertDuplicateStore(self.0)) }
     }
 }
 
-inner!(CertStore, wincrypt::HCERTSTORE);
+inner!(CertStore, Cryptography::HCERTSTORE);
 
 /// Argument to the `add_cert` function indicating how a certificate should be
 /// added to a `CertStore`.
@@ -50,11 +48,11 @@ pub enum CertAdd {
     /// The function makes no check for an existing matching certificate or link
     /// to a matching certificate. A new certificate is always added to the
     /// store. This can lead to duplicates in a store.
-    Always = wincrypt::CERT_STORE_ADD_ALWAYS as isize,
+    Always = Cryptography::CERT_STORE_ADD_ALWAYS as isize,
 
     /// If a matching certificate or a link to a matching certificate exists,
     /// the operation fails.
-    New = wincrypt::CERT_STORE_ADD_NEW as isize,
+    New = Cryptography::CERT_STORE_ADD_NEW as isize,
 
     /// If a matching certificate or a link to a matching certificate exists and
     /// the NotBefore time of the existing context is equal to or greater than
@@ -65,7 +63,7 @@ pub enum CertAdd {
     /// deleted and a new certificate is created and added to the store. If a
     /// matching certificate or a link to a matching certificate does not exist,
     /// a new link is added.
-    Newer = wincrypt::CERT_STORE_ADD_NEWER as isize,
+    Newer = Cryptography::CERT_STORE_ADD_NEWER as isize,
 
     /// If a matching certificate or a link to a matching certificate exists and
     /// the NotBefore time of the existing context is equal to or greater than
@@ -75,19 +73,19 @@ pub enum CertAdd {
     /// time of the new context being added, the existing context is deleted
     /// before creating and adding the new context. The new added context
     /// inherits properties from the existing certificate.
-    NewerInheritProperties = wincrypt::CERT_STORE_ADD_NEWER_INHERIT_PROPERTIES as isize,
+    NewerInheritProperties = Cryptography::CERT_STORE_ADD_NEWER_INHERIT_PROPERTIES as isize,
 
     /// If a link to a matching certificate exists, that existing certificate or
     /// link is deleted and a new certificate is created and added to the store.
     /// If a matching certificate or a link to a matching certificate does not
     /// exist, a new link is added.
-    ReplaceExisting = wincrypt::CERT_STORE_ADD_REPLACE_EXISTING as isize,
+    ReplaceExisting = Cryptography::CERT_STORE_ADD_REPLACE_EXISTING as isize,
 
     /// If a matching certificate exists in the store, the existing context is
     /// not replaced. The existing context inherits properties from the new
     /// certificate.
     ReplaceExistingInheritProperties =
-        wincrypt::CERT_STORE_ADD_REPLACE_EXISTING_INHERIT_PROPERTIES as isize,
+        Cryptography::CERT_STORE_ADD_REPLACE_EXISTING_INHERIT_PROPERTIES as isize,
 
     /// If a matching certificate or a link to a matching certificate exists,
     /// that existing certificate or link is used and properties from the
@@ -96,7 +94,7 @@ pub enum CertAdd {
     ///
     /// If a matching certificate or a link to a matching certificate does
     /// not exist, a new certificate is added.
-    UseExisting = wincrypt::CERT_STORE_ADD_USE_EXISTING as isize,
+    UseExisting = Cryptography::CERT_STORE_ADD_USE_EXISTING as isize,
 }
 
 impl CertStore {
@@ -107,18 +105,21 @@ impl CertStore {
     pub fn open_current_user(which: &str) -> io::Result<CertStore> {
         unsafe {
             let data = OsStr::new(which)
-                             .encode_wide()
-                             .chain(Some(0))
-                             .collect::<Vec<_>>();
-            let store = wincrypt::CertOpenStore(wincrypt::CERT_STORE_PROV_SYSTEM_W as ntdef::LPCSTR,
-                                                0,
-                                                0,
-                                                wincrypt::CERT_SYSTEM_STORE_CURRENT_USER,
-                                                data.as_ptr() as *mut _);
-            if store.is_null() {
-                Err(io::Error::last_os_error())
-            } else {
+                .encode_wide()
+                .chain(Some(0))
+                .collect::<Vec<_>>();
+            let store = Cryptography::CertOpenStore(
+                Cryptography::CERT_STORE_PROV_SYSTEM_W,
+                Cryptography::CERT_QUERY_ENCODING_TYPE::default(),
+                Cryptography::HCRYPTPROV_LEGACY::default(),
+                Cryptography::CERT_SYSTEM_STORE_CURRENT_USER_ID
+                    << Cryptography::CERT_SYSTEM_STORE_LOCATION_SHIFT,
+                data.as_ptr() as *mut _,
+            );
+            if !store.is_null() {
                 Ok(CertStore(store))
+            } else {
+                Err(io::Error::last_os_error())
             }
         }
     }
@@ -130,18 +131,21 @@ impl CertStore {
     pub fn open_local_machine(which: &str) -> io::Result<CertStore> {
         unsafe {
             let data = OsStr::new(which)
-                             .encode_wide()
-                             .chain(Some(0))
-                             .collect::<Vec<_>>();
-            let store = wincrypt::CertOpenStore(wincrypt::CERT_STORE_PROV_SYSTEM_W as ntdef::LPCSTR,
-                                                0,
-                                                0,
-                                                wincrypt::CERT_SYSTEM_STORE_LOCAL_MACHINE,
-                                                data.as_ptr() as *mut _);
-            if store.is_null() {
-                Err(io::Error::last_os_error())
-            } else {
+                .encode_wide()
+                .chain(Some(0))
+                .collect::<Vec<_>>();
+            let store = Cryptography::CertOpenStore(
+                Cryptography::CERT_STORE_PROV_SYSTEM_W,
+                Cryptography::CERT_QUERY_ENCODING_TYPE::default(),
+                Cryptography::HCRYPTPROV_LEGACY::default(),
+                Cryptography::CERT_SYSTEM_STORE_LOCAL_MACHINE_ID
+                    << Cryptography::CERT_SYSTEM_STORE_LOCATION_SHIFT,
+                data.as_ptr() as *mut _,
+            );
+            if !store.is_null() {
                 Ok(CertStore(store))
+            } else {
+                Err(io::Error::last_os_error())
             }
         }
     }
@@ -150,52 +154,56 @@ impl CertStore {
     /// `CertStore` instance.
     ///
     /// The password must also be provided to decrypt the encoded data.
-    pub fn import_pkcs12(data: &[u8],
-                         password: Option<&str>)
-                         -> io::Result<CertStore> {
+    pub fn import_pkcs12(data: &[u8], password: Option<&str>) -> io::Result<CertStore> {
         unsafe {
-            let mut blob = wincrypt::CRYPT_INTEGER_BLOB {
-                cbData: data.len() as winapi::DWORD,
+            let blob = Cryptography::CRYPTOAPI_BLOB {
+                cbData: data.len() as u32,
                 pbData: data.as_ptr() as *mut u8,
             };
             let password = password.map(|s| {
-                OsStr::new(s).encode_wide()
-                             .chain(Some(0))
-                             .collect::<Vec<_>>()
+                OsStr::new(s)
+                    .encode_wide()
+                    .chain(Some(0))
+                    .collect::<Vec<_>>()
             });
             let password = password.as_ref().map(|s| s.as_ptr());
             let password = password.unwrap_or(ptr::null());
-            let res = wincrypt::PFXImportCertStore(&mut blob,
-                                                   password,
-                                                   0);
-            if res.is_null() {
-                Err(io::Error::last_os_error())
-            } else {
+            let res = Cryptography::PFXImportCertStore(
+                &blob,
+                password,
+                Cryptography::CRYPT_KEY_FLAGS::default(),
+            );
+            if !res.is_null() {
                 Ok(CertStore(res))
+            } else {
+                Err(io::Error::last_os_error())
             }
         }
     }
 
     /// Returns an iterator over the certificates in this certificate store.
     pub fn certs(&self) -> Certs {
-        Certs { store: self, cur: None }
+        Certs {
+            store: self,
+            cur: None,
+        }
     }
 
     /// Adds a certificate context to this store.
     ///
     /// This function will add the certificate specified in `cx` to this store.
     /// A copy of the added certificate is returned.
-    pub fn add_cert(&mut self,
-                    cx: &CertContext,
-                    how: CertAdd) -> io::Result<CertContext> {
+    pub fn add_cert(&mut self, cx: &CertContext, how: CertAdd) -> io::Result<CertContext> {
         unsafe {
-            let how = how as winapi::DWORD;
-            let mut ret = ptr::null();
-            let res = wincrypt::CertAddCertificateContextToStore(self.0,
-                                                                 cx.as_inner(),
-                                                                 how,
-                                                                 &mut ret);
-            if res != winapi::TRUE {
+            let how = how as u32;
+            let mut ret = ptr::null_mut();
+            let res = Cryptography::CertAddCertificateContextToStore(
+                self.0,
+                cx.as_inner(),
+                how,
+                &mut ret,
+            );
+            if res == 0 {
                 Err(io::Error::last_os_error())
             } else {
                 Ok(CertContext::from_inner(ret))
@@ -210,25 +218,26 @@ impl CertStore {
     pub fn export_pkcs12(&self, password: &str) -> io::Result<Vec<u8>> {
         unsafe {
             let password = password.encode_utf16().chain(Some(0)).collect::<Vec<_>>();
-            let mut blob = wincrypt::CRYPT_DATA_BLOB {
-                cbData: 0,
-                pbData: 0 as *mut _,
-            };
-            let res = wincrypt::PFXExportCertStore(self.0,
-                                                   &mut blob,
-                                                   password.as_ptr(),
-                                                   wincrypt::EXPORT_PRIVATE_KEYS);
-            if res != winapi::TRUE {
-                return Err(io::Error::last_os_error())
+            let mut blob = mem::zeroed();
+            let res = Cryptography::PFXExportCertStore(
+                self.0,
+                &mut blob,
+                password.as_ptr(),
+                Cryptography::EXPORT_PRIVATE_KEYS,
+            );
+            if res == 0 {
+                return Err(io::Error::last_os_error());
             }
             let mut ret = Vec::with_capacity(blob.cbData as usize);
             blob.pbData = ret.as_mut_ptr();
-            let res = wincrypt::PFXExportCertStore(self.0,
-                                                   &mut blob,
-                                                   password.as_ptr(),
-                                                   wincrypt::EXPORT_PRIVATE_KEYS);
-            if res != winapi::TRUE {
-                return Err(io::Error::last_os_error())
+            let res = Cryptography::PFXExportCertStore(
+                self.0,
+                &mut blob,
+                password.as_ptr(),
+                Cryptography::EXPORT_PRIVATE_KEYS,
+            );
+            if res == 0 {
+                return Err(io::Error::last_os_error());
             }
             ret.set_len(blob.cbData as usize);
             Ok(ret)
@@ -254,7 +263,7 @@ impl<'a> Iterator for Certs<'a> {
                 ptr
             });
             let cur = cur.unwrap_or(ptr::null_mut());
-            let next = wincrypt::CertEnumCertificatesInStore(self.store.0, cur);
+            let next = Cryptography::CertEnumCertificatesInStore(self.store.0, cur);
 
             if next.is_null() {
                 self.cur = None;
@@ -272,7 +281,7 @@ impl<'a> Iterator for Certs<'a> {
 #[derive(Default)]
 pub struct PfxImportOptions {
     password: Option<Vec<u16>>,
-    flags: winapi::DWORD,
+    flags: u32,
 }
 
 impl PfxImportOptions {
@@ -291,17 +300,21 @@ impl PfxImportOptions {
     ///
     /// If not set, private keys are persisted on disk and must be manually deleted.
     pub fn no_persist_key(&mut self, no_persist_key: bool) -> &mut PfxImportOptions {
-        self.flag(wincrypt::PKCS12_NO_PERSIST_KEY, no_persist_key)
+        self.flag(Cryptography::PKCS12_NO_PERSIST_KEY, no_persist_key)
     }
 
     /// If set, all extended properties of the certificate will be imported.
-    pub fn include_extended_properties(&mut self,
-                                       include_extended_properties: bool)
-                                       -> &mut PfxImportOptions {
-        self.flag(wincrypt::PKCS12_INCLUDE_EXTENDED_PROPERTIES, include_extended_properties)
+    pub fn include_extended_properties(
+        &mut self,
+        include_extended_properties: bool,
+    ) -> &mut PfxImportOptions {
+        self.flag(
+            Cryptography::PKCS12_INCLUDE_EXTENDED_PROPERTIES,
+            include_extended_properties,
+        )
     }
 
-    fn flag(&mut self, flag: winapi::DWORD, set: bool) -> &mut PfxImportOptions {
+    fn flag(&mut self, flag: u32, set: bool) -> &mut PfxImportOptions {
         if set {
             self.flags |= flag;
         } else {
@@ -313,17 +326,18 @@ impl PfxImportOptions {
     /// Imports certificates from a PKCS #12 archive, returning a `CertStore` containing them.
     pub fn import(&self, data: &[u8]) -> io::Result<CertStore> {
         unsafe {
-            let mut blob = wincrypt::CRYPT_DATA_BLOB {
-                cbData: cmp::min(data.len(), winapi::DWORD::max_value() as usize) as winapi::DWORD,
-                pbData: data.as_ptr() as *const _ as *mut _,
+            let blob = Cryptography::CRYPTOAPI_BLOB {
+                cbData: cmp::min(data.len(), u32::max_value() as usize) as u32,
+                pbData: data.as_ptr() as *mut _,
             };
             let password = self.password.as_ref().map_or(ptr::null(), |p| p.as_ptr());
 
-            let store = wincrypt::PFXImportCertStore(&mut blob, password, self.flags);
-            if store.is_null() {
-                return Err(io::Error::last_os_error());
+            let store = Cryptography::PFXImportCertStore(&blob, password, self.flags);
+            if !store.is_null() {
+                Ok(CertStore(store))
+            } else {
+                Err(io::Error::last_os_error())
             }
-            Ok(CertStore(store))
         }
     }
 }
@@ -340,15 +354,17 @@ impl Memory {
     /// Initially the returned certificate store contains no certificates.
     pub fn new() -> io::Result<Memory> {
         unsafe {
-            let store = wincrypt::CertOpenStore(wincrypt::CERT_STORE_PROV_MEMORY as ntdef::LPCSTR,
-                                                0,
-                                                0,
-                                                0,
-                                                ptr::null_mut());
-            if store.is_null() {
-                Err(io::Error::last_os_error())
-            } else {
+            let store = Cryptography::CertOpenStore(
+                Cryptography::CERT_STORE_PROV_MEMORY,
+                Cryptography::CERT_QUERY_ENCODING_TYPE::default(),
+                Cryptography::HCRYPTPROV_LEGACY::default(),
+                Cryptography::CERT_OPEN_STORE_FLAGS::default(),
+                ptr::null_mut(),
+            );
+            if !store.is_null() {
                 Ok(Memory(CertStore(store)))
+            } else {
+                Err(io::Error::last_os_error())
             }
         }
     }
@@ -358,16 +374,17 @@ impl Memory {
     /// For example the bytes could be a DER-encoded certificate.
     pub fn add_encoded_certificate(&mut self, cert: &[u8]) -> io::Result<CertContext> {
         unsafe {
-            let mut cert_context = ptr::null();
+            let mut cert_context = ptr::null_mut();
 
-            let res = wincrypt::CertAddEncodedCertificateToStore((self.0).0,
-                                                                 wincrypt::X509_ASN_ENCODING |
-                                                                 wincrypt::PKCS_7_ASN_ENCODING,
-                                                                 cert.as_ptr() as *const _,
-                                                                 cert.len() as winapi::DWORD,
-                                                                 wincrypt::CERT_STORE_ADD_ALWAYS,
-                                                                 &mut cert_context);
-            if res == winapi::TRUE {
+            let res = Cryptography::CertAddEncodedCertificateToStore(
+                (self.0).0,
+                Cryptography::X509_ASN_ENCODING | Cryptography::PKCS_7_ASN_ENCODING,
+                cert.as_ptr(),
+                cert.len() as u32,
+                Cryptography::CERT_STORE_ADD_ALWAYS,
+                &mut cert_context,
+            );
+            if res != 0 {
                 Ok(CertContext::from_inner(cert_context))
             } else {
                 Err(io::Error::last_os_error())
@@ -380,16 +397,17 @@ impl Memory {
     /// This can be created through the `ctl_context::Builder` type.
     pub fn add_encoded_ctl(&mut self, ctl: &[u8]) -> io::Result<CtlContext> {
         unsafe {
-            let mut ctl_context = ptr::null();
+            let mut ctl_context = ptr::null_mut();
 
-            let res = wincrypt::CertAddEncodedCTLToStore((self.0).0,
-                                                         wincrypt::X509_ASN_ENCODING |
-                                                         wincrypt::PKCS_7_ASN_ENCODING,
-                                                         ctl.as_ptr() as *const _,
-                                                         ctl.len() as winapi::DWORD,
-                                                         wincrypt::CERT_STORE_ADD_ALWAYS,
-                                                         &mut ctl_context);
-            if res == winapi::TRUE {
+            let res = Cryptography::CertAddEncodedCTLToStore(
+                (self.0).0,
+                Cryptography::X509_ASN_ENCODING | Cryptography::PKCS_7_ASN_ENCODING,
+                ctl.as_ptr(),
+                ctl.len() as u32,
+                Cryptography::CERT_STORE_ADD_ALWAYS,
+                &mut ctl_context,
+            );
+            if res != 0 {
                 Ok(CtlContext::from_inner(ctl_context))
             } else {
                 Err(io::Error::last_os_error())
@@ -405,8 +423,9 @@ impl Memory {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use crate::ctl_context::CtlContext;
+
+    use super::*;
 
     #[test]
     fn load() {
@@ -432,16 +451,21 @@ mod test {
     fn pfx_import() {
         let pfx = include_bytes!("../test/identity.p12");
         let store = PfxImportOptions::new()
-                        .include_extended_properties(true)
-                        .password("mypass")
-                        .import(pfx)
-                        .unwrap();
+            .include_extended_properties(true)
+            .password("mypass")
+            .import(pfx)
+            .unwrap();
         assert_eq!(store.certs().count(), 2);
-        let pkeys = store.certs()
-                         .filter(|c| {
-                             c.private_key().compare_key(true).silent(true).acquire().is_ok()
-                         })
-                         .count();
+        let pkeys = store
+            .certs()
+            .filter(|c| {
+                c.private_key()
+                    .compare_key(true)
+                    .silent(true)
+                    .acquire()
+                    .is_ok()
+            })
+            .count();
         assert_eq!(pkeys, 1);
     }
 }

--- a/src/context_buffer.rs
+++ b/src/context_buffer.rs
@@ -1,13 +1,14 @@
-use winapi::shared::sspi;
 use std::ops::Deref;
 use std::slice;
 
-pub struct ContextBuffer(pub sspi::SecBuffer);
+use windows_sys::Win32::Security::Authentication::Identity;
+
+pub struct ContextBuffer(pub Identity::SecBuffer);
 
 impl Drop for ContextBuffer {
     fn drop(&mut self) {
         unsafe {
-            sspi::FreeContextBuffer(self.0.pvBuffer);
+            Identity::FreeContextBuffer(self.0.pvBuffer);
         }
     }
 }

--- a/src/crypt_key.rs
+++ b/src/crypt_key.rs
@@ -1,15 +1,16 @@
 //! CryptoAPI private keys.
-use winapi::um::wincrypt;
+
+use windows_sys::Win32::Security::Cryptography;
 
 /// A handle to a key.
-pub struct CryptKey(wincrypt::HCRYPTKEY);
+pub struct CryptKey(usize);
 
 impl Drop for CryptKey {
     fn drop(&mut self) {
         unsafe {
-            wincrypt::CryptDestroyKey(self.0);
+            Cryptography::CryptDestroyKey(self.0);
         }
     }
 }
 
-inner!(CryptKey, wincrypt::HCRYPTKEY);
+inner!(CryptKey, usize);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,13 @@
 #![warn(missing_docs)]
 #![allow(non_upper_case_globals)]
 
-extern crate winapi;
-
 #[macro_use]
 extern crate lazy_static;
 
+use std::ffi::c_void;
 use std::ptr;
-use winapi::ctypes;
-use winapi::shared::sspi;
+
+use windows_sys::Win32::Security::Authentication::Identity;
 
 macro_rules! inner {
     ($t:path, $raw:ty) => {
@@ -37,18 +36,22 @@ macro_rules! inner {
                 self.0 as *mut _
             }
         }
-    }
+    };
 }
 
 /// Allows access to the underlying schannel API representation of a wrapped data type
-/// 
-/// Performing actions with internal handles might lead to the violation of internal assumptions 
+///
+/// Performing actions with internal handles might lead to the violation of internal assumptions
 /// and therefore is inherently unsafe.
 pub trait RawPointer {
     /// Constructs an instance of this type from its handle / pointer.
+    /// # Safety
+    /// This function is unsafe
     unsafe fn from_ptr(t: *mut ::std::os::raw::c_void) -> Self;
 
     /// Get a raw pointer from the underlying handle / pointer.
+    /// # Safety
+    /// This function is unsafe
     unsafe fn as_ptr(&self) -> *mut ::std::os::raw::c_void;
 }
 
@@ -70,15 +73,20 @@ mod security_context;
 #[cfg(test)]
 mod test;
 
-const ACCEPT_REQUESTS: ctypes::c_ulong =
-    sspi::ASC_REQ_ALLOCATE_MEMORY | sspi::ASC_REQ_CONFIDENTIALITY |
-    sspi::ASC_REQ_SEQUENCE_DETECT | sspi::ASC_REQ_STREAM |
-    sspi::ASC_REQ_REPLAY_DETECT;
+const ACCEPT_REQUESTS: u32 = Identity::ASC_REQ_ALLOCATE_MEMORY
+    | Identity::ASC_REQ_CONFIDENTIALITY
+    | Identity::ASC_REQ_SEQUENCE_DETECT
+    | Identity::ASC_REQ_STREAM
+    | Identity::ASC_REQ_REPLAY_DETECT;
 
-const INIT_REQUESTS: ctypes::c_ulong =
-    sspi::ISC_REQ_CONFIDENTIALITY | sspi::ISC_REQ_INTEGRITY | sspi::ISC_REQ_REPLAY_DETECT |
-    sspi::ISC_REQ_SEQUENCE_DETECT | sspi::ISC_REQ_MANUAL_CRED_VALIDATION |
-    sspi::ISC_REQ_ALLOCATE_MEMORY | sspi::ISC_REQ_STREAM | sspi::ISC_REQ_USE_SUPPLIED_CREDS;
+const INIT_REQUESTS: u32 = Identity::ISC_REQ_CONFIDENTIALITY
+    | Identity::ISC_REQ_INTEGRITY
+    | Identity::ISC_REQ_REPLAY_DETECT
+    | Identity::ISC_REQ_SEQUENCE_DETECT
+    | Identity::ISC_REQ_MANUAL_CRED_VALIDATION
+    | Identity::ISC_REQ_ALLOCATE_MEMORY
+    | Identity::ISC_REQ_STREAM
+    | Identity::ISC_REQ_USE_SUPPLIED_CREDS;
 
 trait Inner<T> {
     unsafe fn from_inner(t: T) -> Self;
@@ -88,23 +96,22 @@ trait Inner<T> {
     fn get_mut(&mut self) -> &mut T;
 }
 
-unsafe fn secbuf(buftype: ctypes::c_ulong,
-                 bytes: Option<&mut [u8]>) -> sspi::SecBuffer {
+unsafe fn secbuf(buftype: u32, bytes: Option<&mut [u8]>) -> Identity::SecBuffer {
     let (ptr, len) = match bytes {
-        Some(bytes) => (bytes.as_mut_ptr(), bytes.len() as ctypes::c_ulong),
+        Some(bytes) => (bytes.as_mut_ptr(), bytes.len() as u32),
         None => (ptr::null_mut(), 0),
     };
-    sspi::SecBuffer {
+    Identity::SecBuffer {
         BufferType: buftype,
         cbBuffer: len,
-        pvBuffer: ptr as *mut ctypes::c_void,
+        pvBuffer: ptr as *mut c_void,
     }
 }
 
-unsafe fn secbuf_desc(bufs: &mut [sspi::SecBuffer]) -> sspi::SecBufferDesc {
-    sspi::SecBufferDesc {
-        ulVersion: sspi::SECBUFFER_VERSION,
-        cBuffers: bufs.len() as ctypes::c_ulong,
+unsafe fn secbuf_desc(bufs: &mut [Identity::SecBuffer]) -> Identity::SecBufferDesc {
+    Identity::SecBufferDesc {
+        ulVersion: Identity::SECBUFFER_VERSION,
+        cBuffers: bufs.len() as u32,
         pBuffers: bufs.as_mut_ptr(),
     }
 }

--- a/src/ncrypt_key.rs
+++ b/src/ncrypt_key.rs
@@ -1,15 +1,16 @@
 //! CNG private keys.
-use winapi::um::ncrypt;
+
+use windows_sys::Win32::Security::Cryptography;
 
 /// A CNG handle to a key.
-pub struct NcryptKey(ncrypt::NCRYPT_KEY_HANDLE);
+pub struct NcryptKey(Cryptography::NCRYPT_KEY_HANDLE);
 
 impl Drop for NcryptKey {
     fn drop(&mut self) {
         unsafe {
-            ncrypt::NCryptFreeObject(self.0);
+            Cryptography::NCryptFreeObject(self.0);
         }
     }
 }
 
-inner!(NcryptKey, ncrypt::NCRYPT_KEY_HANDLE);
+inner!(NcryptKey, Cryptography::NCRYPT_KEY_HANDLE);

--- a/src/schannel_cred.rs
+++ b/src/schannel_cred.rs
@@ -1,17 +1,17 @@
 //! Schannel credentials.
-use winapi::shared::{sspi, winerror};
-use winapi::shared::minwindef as winapi;
-use winapi::um::{self, wincrypt};
-use std::io;
-use std::mem;
 use std::ptr;
 use std::sync::Arc;
+use std::{io, mem};
 
-use crate::Inner;
+use windows_sys::Win32::Foundation;
+use windows_sys::Win32::Security::Authentication::Identity;
+use windows_sys::Win32::Security::{Credentials, Cryptography};
+
 use crate::cert_context::CertContext;
+use crate::Inner;
 
 lazy_static! {
-    static ref UNISP_NAME: Vec<u8> = um::schannel::UNISP_NAME.bytes().chain(Some(0)).collect();
+    static ref UNISP_NAME: Vec<u8> = Identity::UNISP_NAME.bytes().chain(Some(0)).collect();
 }
 
 /// The communication direction that an `SchannelCred` will support.
@@ -27,80 +27,130 @@ pub enum Direction {
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa375549(v=vs.85).aspx
 #[derive(Debug, Copy, Clone)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum Algorithm {
     /// Advanced Encryption Standard (AES).
-    Aes = wincrypt::CALG_AES,
+    Aes = Cryptography::ALG_CLASS_DATA_ENCRYPT
+        | Cryptography::ALG_TYPE_BLOCK
+        | Cryptography::ALG_SID_AES,
     /// 128 bit AES.
-    Aes128 = wincrypt::CALG_AES_128,
+    Aes128 = Cryptography::ALG_CLASS_DATA_ENCRYPT
+        | Cryptography::ALG_TYPE_BLOCK
+        | Cryptography::ALG_SID_AES_128,
     /// 192 bit AES.
-    Aes192 = wincrypt::CALG_AES_192,
+    Aes192 = Cryptography::ALG_CLASS_DATA_ENCRYPT
+        | Cryptography::ALG_TYPE_BLOCK
+        | Cryptography::ALG_SID_AES_192,
     /// 256 bit AES.
-    Aes256 = wincrypt::CALG_AES_256,
+    Aes256 = Cryptography::ALG_CLASS_DATA_ENCRYPT
+        | Cryptography::ALG_TYPE_BLOCK
+        | Cryptography::ALG_SID_AES_256,
     /// Temporary algorithm identifier for handles of Diffie-Hellman–agreed keys.
-    AgreedkeyAny = wincrypt::CALG_AGREEDKEY_ANY,
+    AgreedkeyAny = Cryptography::ALG_CLASS_KEY_EXCHANGE
+        | Cryptography::ALG_TYPE_DH
+        | Cryptography::ALG_SID_AGREED_KEY_ANY,
     /// An algorithm to create a 40-bit DES key that has parity bits and zeroed key bits to make
     /// its key length 64 bits.
-    CylinkMek = wincrypt::CALG_CYLINK_MEK,
+    CylinkMek = Cryptography::ALG_CLASS_DATA_ENCRYPT
+        | Cryptography::ALG_TYPE_BLOCK
+        | Cryptography::ALG_SID_CYLINK_MEK,
     /// DES encryption algorithm.
-    Des = wincrypt::CALG_DES,
+    Des = Cryptography::ALG_CLASS_DATA_ENCRYPT
+        | Cryptography::ALG_TYPE_BLOCK
+        | Cryptography::ALG_SID_DES,
     /// DESX encryption algorithm.
-    Desx = wincrypt::CALG_DESX,
+    Desx = Cryptography::ALG_CLASS_DATA_ENCRYPT
+        | Cryptography::ALG_TYPE_BLOCK
+        | Cryptography::ALG_SID_DESX,
     /// Diffie-Hellman ephemeral key exchange algorithm.
-    DhEphem = wincrypt::CALG_DH_EPHEM,
+    DhEphem = Cryptography::ALG_CLASS_KEY_EXCHANGE
+        | Cryptography::ALG_TYPE_DH
+        | Cryptography::ALG_SID_DH_EPHEM,
     /// Diffie-Hellman store and forward key exchange algorithm.
-    DhSf = wincrypt::CALG_DH_SF,
+    DhSf = Cryptography::ALG_CLASS_KEY_EXCHANGE
+        | Cryptography::ALG_TYPE_DH
+        | Cryptography::ALG_SID_DH_SANDF,
     /// DSA public key signature algorithm.
-    DssSign = wincrypt::CALG_DSS_SIGN,
+    DssSign = Cryptography::ALG_CLASS_SIGNATURE
+        | Cryptography::ALG_TYPE_DSS
+        | Cryptography::ALG_SID_DSS_ANY,
     /// Elliptic curve Diffie-Hellman key exchange algorithm.
-    Ecdh = wincrypt::CALG_ECDH,
+    Ecdh = Cryptography::ALG_CLASS_KEY_EXCHANGE
+        | Cryptography::ALG_TYPE_DH
+        | Cryptography::ALG_SID_ECDH,
     /// Ephemeral elliptic curve Diffie-Hellman key exchange algorithm.
-    EcdhEphem = wincrypt::CALG_ECDH_EPHEM,
+    EcdhEphem = Cryptography::ALG_CLASS_KEY_EXCHANGE
+        | Cryptography::ALG_TYPE_ECDH
+        | Cryptography::ALG_SID_ECDH_EPHEM,
     /// Elliptic curve digital signature algorithm.
-    Ecdsa = wincrypt::CALG_ECDSA,
+    Ecdsa = Cryptography::ALG_CLASS_SIGNATURE
+        | Cryptography::ALG_TYPE_DSS
+        | Cryptography::ALG_SID_ECDSA,
     /// One way function hashing algorithm.
-    HashReplaceOwf = wincrypt::CALG_HASH_REPLACE_OWF,
+    HashReplaceOwf = Cryptography::ALG_CLASS_HASH
+        | Cryptography::ALG_TYPE_ANY
+        | Cryptography::ALG_SID_HASH_REPLACE_OWF,
     /// Hughes MD5 hashing algorithm.
-    HughesMd5 = wincrypt::CALG_HUGHES_MD5,
+    HughesMd5 = Cryptography::ALG_CLASS_KEY_EXCHANGE
+        | Cryptography::ALG_TYPE_ANY
+        | Cryptography::ALG_SID_MD5,
     /// HMAC keyed hash algorithm.
-    Hmac = wincrypt::CALG_HMAC,
+    Hmac = Cryptography::ALG_CLASS_HASH | Cryptography::ALG_TYPE_ANY | Cryptography::ALG_SID_HMAC,
     /// MAC keyed hash algorithm.
-    Mac = wincrypt::CALG_MAC,
+    Mac = Cryptography::ALG_CLASS_HASH | Cryptography::ALG_TYPE_ANY | Cryptography::ALG_SID_MAC,
     /// MD2 hashing algorithm.
-    Md2 = wincrypt::CALG_MD2,
+    Md2 = Cryptography::ALG_CLASS_HASH | Cryptography::ALG_TYPE_ANY | Cryptography::ALG_SID_MD2,
     /// MD4 hashing algorithm.
-    Md4 = wincrypt::CALG_MD4,
+    Md4 = Cryptography::ALG_CLASS_HASH | Cryptography::ALG_TYPE_ANY | Cryptography::ALG_SID_MD4,
     /// MD5 hashing algorithm.
-    Md5 = wincrypt::CALG_MD5,
+    Md5 = Cryptography::ALG_CLASS_HASH | Cryptography::ALG_TYPE_ANY | Cryptography::ALG_SID_MD5,
     /// No signature algorithm..
-    NoSign = wincrypt::CALG_NO_SIGN,
+    NoSign =
+        Cryptography::ALG_CLASS_SIGNATURE | Cryptography::ALG_TYPE_ANY | Cryptography::ALG_SID_ANY,
     /// RC2 block encryption algorithm.
-    Rc2 = wincrypt::CALG_RC2,
+    Rc2 = Cryptography::ALG_CLASS_DATA_ENCRYPT
+        | Cryptography::ALG_TYPE_BLOCK
+        | Cryptography::ALG_SID_RC2,
     /// RC4 stream encryption algorithm.
-    Rc4 = wincrypt::CALG_RC4,
+    Rc4 = Cryptography::ALG_CLASS_DATA_ENCRYPT
+        | Cryptography::ALG_TYPE_STREAM
+        | Cryptography::ALG_SID_RC4,
     /// RC5 block encryption algorithm.
-    Rc5 = wincrypt::CALG_RC5,
+    Rc5 = Cryptography::ALG_CLASS_DATA_ENCRYPT
+        | Cryptography::ALG_TYPE_BLOCK
+        | Cryptography::ALG_SID_RC5,
     /// RSA public key exchange algorithm.
-    RsaKeyx = wincrypt::CALG_RSA_KEYX,
+    RsaKeyx = Cryptography::ALG_CLASS_KEY_EXCHANGE
+        | Cryptography::ALG_TYPE_RSA
+        | Cryptography::ALG_SID_RSA_ANY,
     /// RSA public key signature algorithm.
-    RsaSign = wincrypt::CALG_RSA_SIGN,
+    RsaSign = Cryptography::ALG_CLASS_SIGNATURE
+        | Cryptography::ALG_TYPE_RSA
+        | Cryptography::ALG_SID_RSA_ANY,
     /// SHA hashing algorithm.
-    Sha1 = wincrypt::CALG_SHA1,
+    Sha1 = Cryptography::ALG_CLASS_HASH | Cryptography::ALG_TYPE_ANY | Cryptography::ALG_SID_SHA1,
     /// 256 bit SHA hashing algorithm.
-    Sha256 = wincrypt::CALG_SHA_256,
+    Sha256 =
+        Cryptography::ALG_CLASS_HASH | Cryptography::ALG_TYPE_ANY | Cryptography::ALG_SID_SHA_256,
     /// 384 bit SHA hashing algorithm.
-    Sha384 = wincrypt::CALG_SHA_384,
+    Sha384 =
+        Cryptography::ALG_CLASS_HASH | Cryptography::ALG_TYPE_ANY | Cryptography::ALG_SID_SHA_384,
     /// 512 bit SHA hashing algorithm.
-    Sha512 = wincrypt::CALG_SHA_512,
+    Sha512 =
+        Cryptography::ALG_CLASS_HASH | Cryptography::ALG_TYPE_ANY | Cryptography::ALG_SID_SHA_512,
     /// Triple DES encryption algorithm.
-    TripleDes = wincrypt::CALG_3DES,
+    TripleDes = Cryptography::ALG_CLASS_DATA_ENCRYPT
+        | Cryptography::ALG_TYPE_BLOCK
+        | Cryptography::ALG_SID_3DES,
     /// Two-key triple DES encryption with effective key length equal to 112 bits.
-    TripleDes112 = wincrypt::CALG_3DES_112,
-    #[doc(hidden)]
-    __ForExtensibility,
+    TripleDes112 = Cryptography::ALG_CLASS_DATA_ENCRYPT
+        | Cryptography::ALG_TYPE_BLOCK
+        | Cryptography::ALG_SID_3DES_112,
 }
 
 /// Protocols supported by Schannel.
 #[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
 pub enum Protocol {
     /// Secure Sockets Layer 3.0
     Ssl3,
@@ -110,22 +160,23 @@ pub enum Protocol {
     Tls11,
     /// Transport Layer Security 1.2
     Tls12,
-    #[doc(hidden)]
-    __ForExtensibility,
+    /// Transport Layer Security 1.3
+    Tls13,
 }
 
 impl Protocol {
-    fn dword(self, direction: Direction) -> winapi::DWORD {
+    fn dword(self, direction: Direction) -> u32 {
         match (self, direction) {
-            (Protocol::Ssl3, Direction::Inbound) => um::schannel::SP_PROT_SSL3_SERVER,
-            (Protocol::Tls10, Direction::Inbound) => um::schannel::SP_PROT_TLS1_0_SERVER,
-            (Protocol::Tls11, Direction::Inbound) => um::schannel::SP_PROT_TLS1_1_SERVER,
-            (Protocol::Tls12, Direction::Inbound) => um::schannel::SP_PROT_TLS1_2_SERVER,
-            (Protocol::Ssl3, Direction::Outbound) => um::schannel::SP_PROT_SSL3_CLIENT,
-            (Protocol::Tls10, Direction::Outbound) => um::schannel::SP_PROT_TLS1_0_CLIENT,
-            (Protocol::Tls11, Direction::Outbound) => um::schannel::SP_PROT_TLS1_1_CLIENT,
-            (Protocol::Tls12, Direction::Outbound) => um::schannel::SP_PROT_TLS1_2_CLIENT,
-            (Protocol::__ForExtensibility, _) => unreachable!(),
+            (Protocol::Ssl3, Direction::Inbound) => Identity::SP_PROT_SSL3_SERVER,
+            (Protocol::Tls10, Direction::Inbound) => Identity::SP_PROT_TLS1_0_SERVER,
+            (Protocol::Tls11, Direction::Inbound) => Identity::SP_PROT_TLS1_1_SERVER,
+            (Protocol::Tls12, Direction::Inbound) => Identity::SP_PROT_TLS1_2_SERVER,
+            (Protocol::Tls13, Direction::Inbound) => Identity::SP_PROT_TLS1_3_SERVER,
+            (Protocol::Ssl3, Direction::Outbound) => Identity::SP_PROT_SSL3_CLIENT,
+            (Protocol::Tls10, Direction::Outbound) => Identity::SP_PROT_TLS1_0_CLIENT,
+            (Protocol::Tls11, Direction::Outbound) => Identity::SP_PROT_TLS1_1_CLIENT,
+            (Protocol::Tls12, Direction::Outbound) => Identity::SP_PROT_TLS1_2_CLIENT,
+            (Protocol::Tls13, Direction::Outbound) => Identity::SP_PROT_TLS1_3_CLIENT,
         }
     }
 }
@@ -145,31 +196,13 @@ impl Builder {
     }
 
     /// Sets the algorithms supported for credentials created from this builder.
-    pub fn supported_algorithms(&mut self,
-                                supported_algorithms: &[Algorithm])
-                                -> &mut Builder {
-        assert!(supported_algorithms.iter()
-            .all(|a| {
-                match *a {
-                    Algorithm::__ForExtensibility => false,
-                    _ => true,
-                }
-            }));
+    pub fn supported_algorithms(&mut self, supported_algorithms: &[Algorithm]) -> &mut Builder {
         self.supported_algorithms = Some(supported_algorithms.to_owned());
         self
     }
 
     /// Sets the protocols enabled for credentials created from this builder.
-    pub fn enabled_protocols(&mut self,
-                             enabled_protocols: &[Protocol])
-                             -> &mut Builder {
-        assert!(enabled_protocols.iter()
-            .all(|a| {
-                match *a {
-                    Protocol::__ForExtensibility => false,
-                    _ => true,
-                }
-            }));
+    pub fn enabled_protocols(&mut self, enabled_protocols: &[Protocol]) -> &mut Builder {
         self.enabled_protocols = Some(enabled_protocols.to_owned());
         self
     }
@@ -191,39 +224,43 @@ impl Builder {
     /// Creates a new `SchannelCred`.
     pub fn acquire(&self, direction: Direction) -> io::Result<SchannelCred> {
         unsafe {
-            let mut handle = mem::zeroed();
-            let mut cred_data: um::schannel::SCHANNEL_CRED = mem::zeroed();
-            cred_data.dwVersion = um::schannel::SCHANNEL_CRED_VERSION;
-            cred_data.dwFlags = um::schannel::SCH_USE_STRONG_CRYPTO | um::schannel::SCH_CRED_NO_DEFAULT_CREDS;
+            let mut handle: Credentials::SecHandle = mem::zeroed();
+            let mut cred_data: Identity::SCHANNEL_CRED = mem::zeroed();
+            cred_data.dwVersion = Identity::SCHANNEL_CRED_VERSION;
+            cred_data.dwFlags =
+                Identity::SCH_USE_STRONG_CRYPTO | Identity::SCH_CRED_NO_DEFAULT_CREDS;
             if let Some(ref supported_algorithms) = self.supported_algorithms {
-                cred_data.cSupportedAlgs = supported_algorithms.len() as winapi::DWORD;
+                cred_data.cSupportedAlgs = supported_algorithms.len() as u32;
                 cred_data.palgSupportedAlgs = supported_algorithms.as_ptr() as *mut _;
             }
             if let Some(ref enabled_protocols) = self.enabled_protocols {
-                cred_data.grbitEnabledProtocols = enabled_protocols.iter()
+                cred_data.grbitEnabledProtocols = enabled_protocols
+                    .iter()
                     .map(|p| p.dword(direction))
                     .fold(0, |acc, p| acc | p);
             }
             let mut certs = self.certs.iter().map(|c| c.as_inner()).collect::<Vec<_>>();
-            cred_data.cCreds = certs.len() as winapi::DWORD;
-            cred_data.paCred = certs.as_mut_ptr();
+            cred_data.cCreds = certs.len() as u32;
+            cred_data.paCred = certs.as_mut_ptr() as _;
 
             let direction = match direction {
-                Direction::Inbound => sspi::SECPKG_CRED_INBOUND,
-                Direction::Outbound => sspi::SECPKG_CRED_OUTBOUND,
+                Direction::Inbound => Identity::SECPKG_CRED_INBOUND,
+                Direction::Outbound => Identity::SECPKG_CRED_OUTBOUND,
             };
 
-            match sspi::AcquireCredentialsHandleA(ptr::null_mut(),
-                                                  UNISP_NAME.as_ptr() as *const _ as *mut _,
-                                                  direction,
-                                                  ptr::null_mut(),
-                                                  &mut cred_data as *mut _ as *mut _,
-                                                  None,
-                                                  ptr::null_mut(),
-                                                  &mut handle,
-                                                  ptr::null_mut()) {
-                winerror::SEC_E_OK => Ok(SchannelCred::from_inner(handle)),
-                err => Err(io::Error::from_raw_os_error(err as i32)),
+            match Identity::AcquireCredentialsHandleA(
+                ptr::null(),
+                UNISP_NAME.as_ptr(),
+                direction,
+                ptr::null_mut(),
+                &mut cred_data as *const _ as *const _,
+                None,
+                ptr::null_mut(),
+                &mut handle,
+                ptr::null_mut(),
+            ) {
+                Foundation::SEC_E_OK => Ok(SchannelCred::from_inner(handle)),
+                err => Err(io::Error::from_raw_os_error(err)),
             }
         }
     }
@@ -233,12 +270,12 @@ impl Builder {
 #[derive(Clone)]
 pub struct SchannelCred(Arc<RawCredHandle>);
 
-struct RawCredHandle(sspi::CredHandle);
+struct RawCredHandle(Credentials::SecHandle);
 
 impl Drop for RawCredHandle {
     fn drop(&mut self) {
         unsafe {
-            sspi::FreeCredentialsHandle(&mut self.0);
+            Identity::FreeCredentialsHandle(&self.0);
         }
     }
 }
@@ -249,11 +286,11 @@ impl SchannelCred {
         Builder::new()
     }
 
-    unsafe fn from_inner(inner: sspi::CredHandle) -> SchannelCred {
+    unsafe fn from_inner(inner: Credentials::SecHandle) -> SchannelCred {
         SchannelCred(Arc::new(RawCredHandle(inner)))
     }
 
-    pub(crate) fn as_inner(&self) -> sspi::CredHandle {
+    pub(crate) fn as_inner(&self) -> Credentials::SecHandle {
         self.0.as_ref().0
     }
 }

--- a/src/security_context.rs
+++ b/src/security_context.rs
@@ -1,136 +1,133 @@
-use winapi::shared::{sspi, winerror};
-use winapi::shared::minwindef::ULONG;
-use winapi::um::{minschannel, schannel};
+use std::io;
 use std::mem;
 use std::ptr;
-use std::io;
 
-use crate::{INIT_REQUESTS, Inner, secbuf, secbuf_desc};
+use windows_sys::Win32::Foundation;
+use windows_sys::Win32::Security::Authentication::Identity;
+use windows_sys::Win32::Security::Credentials;
+
 use crate::alpn_list::AlpnList;
 use crate::cert_context::CertContext;
 use crate::context_buffer::ContextBuffer;
-
 use crate::schannel_cred::SchannelCred;
+use crate::{secbuf, secbuf_desc, Inner, INIT_REQUESTS};
 
-pub struct SecurityContext(sspi::CtxtHandle);
+pub struct SecurityContext(Credentials::SecHandle);
 
 impl Drop for SecurityContext {
     fn drop(&mut self) {
         unsafe {
-            sspi::DeleteSecurityContext(&mut self.0);
+            Identity::DeleteSecurityContext(&self.0);
         }
     }
 }
 
-impl Inner<sspi::CtxtHandle> for SecurityContext {
-    unsafe fn from_inner(inner: sspi::CtxtHandle) -> SecurityContext {
+impl Inner<Credentials::SecHandle> for SecurityContext {
+    unsafe fn from_inner(inner: Credentials::SecHandle) -> SecurityContext {
         SecurityContext(inner)
     }
 
-    fn as_inner(&self) -> sspi::CtxtHandle {
+    fn as_inner(&self) -> Credentials::SecHandle {
         self.0
     }
 
-    fn get_mut(&mut self) -> &mut sspi::CtxtHandle {
+    fn get_mut(&mut self) -> &mut Credentials::SecHandle {
         &mut self.0
     }
 }
 
 impl SecurityContext {
-    pub fn initialize(cred: &mut SchannelCred,
-                      accept: bool,
-                      domain: Option<&[u16]>,
-                      requested_application_protocols: &Option<Vec<Vec<u8>>>)
-                      -> io::Result<(SecurityContext, Option<ContextBuffer>)> {
+    pub fn initialize(
+        cred: &mut SchannelCred,
+        accept: bool,
+        domain: Option<&[u16]>,
+        requested_application_protocols: &Option<Vec<Vec<u8>>>,
+    ) -> io::Result<(SecurityContext, Option<ContextBuffer>)> {
         unsafe {
             let mut ctxt = mem::zeroed();
 
             if accept {
                 // If we're performing an accept then we need to wait to call
                 // `AcceptSecurityContext` until we've actually read some data.
-                return Ok((SecurityContext(ctxt), None))
+                return Ok((SecurityContext(ctxt), None));
             }
 
-            let domain = domain.map(|b| b.as_ptr() as *mut u16).unwrap_or(ptr::null_mut());
+            let domain = domain.map(|b| b.as_ptr()).unwrap_or(ptr::null_mut());
 
             let mut inbufs = vec![];
 
             // Make sure `AlpnList` is kept alive for the duration of this function.
-            let mut alpns = requested_application_protocols.as_ref().map(|alpn| AlpnList::new(&alpn));
+            let mut alpns = requested_application_protocols
+                .as_ref()
+                .map(|alpn| AlpnList::new(alpn));
             if let Some(ref mut alpns) = alpns {
-                inbufs.push(secbuf(sspi::SECBUFFER_APPLICATION_PROTOCOLS,
-                                   Some(&mut alpns[..])));
+                inbufs.push(secbuf(
+                    Identity::SECBUFFER_APPLICATION_PROTOCOLS,
+                    Some(&mut alpns[..]),
+                ));
             };
 
-            let mut inbuf_desc = secbuf_desc(&mut inbufs[..]);
+            let inbuf_desc = secbuf_desc(&mut inbufs[..]);
 
-            let mut outbuf = [secbuf(sspi::SECBUFFER_EMPTY, None)];
+            let mut outbuf = [secbuf(Identity::SECBUFFER_EMPTY, None)];
             let mut outbuf_desc = secbuf_desc(&mut outbuf);
 
             let mut attributes = 0;
 
-            match sspi::InitializeSecurityContextW(&mut cred.as_inner(),
-                                                   ptr::null_mut(),
-                                                   domain,
-                                                   INIT_REQUESTS,
-                                                   0,
-                                                   0,
-                                                   &mut inbuf_desc,
-                                                   0,
-                                                   &mut ctxt,
-                                                   &mut outbuf_desc,
-                                                   &mut attributes,
-                                                   ptr::null_mut()) {
-                winerror::SEC_I_CONTINUE_NEEDED => {
+            match Identity::InitializeSecurityContextW(
+                &cred.as_inner(),
+                ptr::null_mut(),
+                domain,
+                INIT_REQUESTS,
+                0,
+                0,
+                &inbuf_desc,
+                0,
+                &mut ctxt,
+                &mut outbuf_desc,
+                &mut attributes,
+                ptr::null_mut(),
+            ) {
+                Foundation::SEC_I_CONTINUE_NEEDED => {
                     Ok((SecurityContext(ctxt), Some(ContextBuffer(outbuf[0]))))
                 }
-                err => {
-                    Err(io::Error::from_raw_os_error(err as i32))
-                }
+                err => Err(io::Error::from_raw_os_error(err)),
             }
         }
     }
 
-    unsafe fn attribute<T>(&self, attr: ULONG) -> io::Result<T> {
-        let mut value = std::mem::zeroed();
-        let status = sspi::QueryContextAttributesW(&self.0 as *const _ as *mut _,
-                                                   attr,
-                                                   &mut value as *mut _ as *mut _);
-        if status == winerror::SEC_E_OK {
-            Ok(value)
-        } else {
-            Err(io::Error::from_raw_os_error(status as i32))
+    unsafe fn attribute<T>(&self, attr: Identity::SECPKG_ATTR) -> io::Result<T> {
+        let mut value = mem::zeroed();
+        let status =
+            Identity::QueryContextAttributesW(&self.0, attr, &mut value as *mut _ as *mut _);
+        match status {
+            Foundation::SEC_E_OK => Ok(value),
+            err => Err(io::Error::from_raw_os_error(err)),
         }
     }
 
-    pub fn application_protocol(&self) -> io::Result<sspi::SecPkgContext_ApplicationProtocol> {
-        unsafe {
-            self.attribute(sspi::SECPKG_ATTR_APPLICATION_PROTOCOL)
-        }
+    pub fn application_protocol(&self) -> io::Result<Identity::SecPkgContext_ApplicationProtocol> {
+        unsafe { self.attribute(Identity::SECPKG_ATTR_APPLICATION_PROTOCOL) }
     }
 
-    pub fn session_info(&self) -> io::Result<schannel::SecPkgContext_SessionInfo> {
-        unsafe {
-            self.attribute(minschannel::SECPKG_ATTR_SESSION_INFO)
-        }
+    pub fn session_info(&self) -> io::Result<Identity::SecPkgContext_SessionInfo> {
+        unsafe { self.attribute(Identity::SECPKG_ATTR_SESSION_INFO) }
     }
 
-    pub fn stream_sizes(&self) -> io::Result<sspi::SecPkgContext_StreamSizes> {
-        unsafe {
-            self.attribute(sspi::SECPKG_ATTR_STREAM_SIZES)
-        }
+    pub fn stream_sizes(&self) -> io::Result<Identity::SecPkgContext_StreamSizes> {
+        unsafe { self.attribute(Identity::SECPKG_ATTR_STREAM_SIZES) }
     }
 
     pub fn remote_cert(&self) -> io::Result<CertContext> {
         unsafe {
-            self.attribute(minschannel::SECPKG_ATTR_REMOTE_CERT_CONTEXT)
+            self.attribute(Identity::SECPKG_ATTR_REMOTE_CERT_CONTEXT)
                 .map(|p| CertContext::from_inner(p))
         }
     }
 
     pub fn local_cert(&self) -> io::Result<CertContext> {
         unsafe {
-            self.attribute(minschannel::SECPKG_ATTR_LOCAL_CERT_CONTEXT)
+            self.attribute(Identity::SECPKG_ATTR_LOCAL_CERT_CONTEXT)
                 .map(|p| CertContext::from_inner(p))
         }
     }


### PR DESCRIPTION
This PR resolves #75. Important bullet points:
* I have used `windows-sys` crate which is roughly equivalent to winapi. The higher-level `windows` crate doesn't currently work well with the functions returning HRESULT and suffers from occasional breaking changes in the APIs
* The MSRV is 1.40 due to added `non_exhaustive` pattern which replaces the manual one on several enums
* The code was formatted with rustfmt and updated to 2018 edition
* Fixed a few minor clippy warnings
* Tested with both -msvc and -gnu targets
* Mostly translates one to one with a few tweaks around mutability and types