### PR TITLE
Remove dependency on `lazy_static`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
-lazy_static = "1.0"
 windows-sys = { version = "0.36", features = [
     "Win32_Foundation", "Win32_Security_Cryptography",
     "Win32_Security_Authentication_Identity", "Win32_Security_Credentials",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   - TARGET: x86_64-pc-windows-gnu
     VERSION: nightly
   - TARGET: i686-pc-windows-gnu
-    VERSION: 1.40.0
+    VERSION: 1.46.0
   access_token:
     secure: ZxcrtxQXwszRYNN6c1ZIagczEqzmQQZeYHY58izcmF0jdq/cptxJvFUoVxDmnoqj
 install:

--- a/src/ctl_context.rs
+++ b/src/ctl_context.rs
@@ -11,12 +11,7 @@ use windows_sys::Win32::Security::Cryptography;
 use crate::cert_context::CertContext;
 use crate::Inner;
 
-lazy_static! {
-    static ref szOID_OIWSEC_sha1: Vec<u8> = Cryptography::szOID_OIWSEC_sha1
-        .bytes()
-        .chain(Some(0))
-        .collect();
-}
+static szOID_OIWSEC_sha1: &[u8] = null_terminate!(Cryptography::szOID_OIWSEC_sha1);
 
 /// Wrapped `PCCTL_CONTEXT` which represents a certificate trust list to
 /// Windows.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,6 @@
 #![warn(missing_docs)]
 #![allow(non_upper_case_globals)]
 
-#[macro_use]
-extern crate lazy_static;
-
 use std::ffi::c_void;
 use std::ptr;
 
@@ -37,6 +34,27 @@ macro_rules! inner {
             }
         }
     };
+}
+
+macro_rules! null_terminate {
+    ($input:expr) => {{
+        const OUTPUT: [u8; $input.as_bytes().len() + 1] = {
+            let mut output = [0u8; $input.as_bytes().len() + 1];
+
+            let input = $input.as_bytes();
+
+            // The output is 1 byte longer, so the last byte stays initialized to 0
+            let mut i = 0usize;
+            while i < input.len() {
+                output[i] = input[i];
+                i += 1;
+            }
+
+            output
+        };
+
+        &OUTPUT
+    }};
 }
 
 /// Allows access to the underlying schannel API representation of a wrapped data type

--- a/src/schannel_cred.rs
+++ b/src/schannel_cred.rs
@@ -10,9 +10,7 @@ use windows_sys::Win32::Security::{Credentials, Cryptography};
 use crate::cert_context::CertContext;
 use crate::Inner;
 
-lazy_static! {
-    static ref UNISP_NAME: Vec<u8> = Identity::UNISP_NAME.bytes().chain(Some(0)).collect();
-}
+static UNISP_NAME: &[u8] = null_terminate!(Identity::UNISP_NAME);
 
 /// The communication direction that an `SchannelCred` will support.
 #[derive(Copy, Debug, Clone, PartialEq, Eq)]

--- a/src/test.rs
+++ b/src/test.rs
@@ -405,12 +405,7 @@ fn session_resumption_thread_safety() {
 
 const FRIENDLY_NAME: &str = "schannel-rs localhost testing cert";
 
-lazy_static! {
-    static ref szOID_RSA_SHA256RSA: Vec<u8> = Cryptography::szOID_RSA_SHA256RSA
-        .bytes()
-        .chain(Some(0))
-        .collect();
-}
+static szOID_RSA_SHA256RSA: &[u8] = null_terminate!(Cryptography::szOID_RSA_SHA256RSA);
 
 fn install_certificate() -> io::Result<CertContext> {
     unsafe {

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -22,20 +22,9 @@ use crate::schannel_cred::SchannelCred;
 use crate::security_context::SecurityContext;
 use crate::{secbuf, secbuf_desc, Inner, ACCEPT_REQUESTS, INIT_REQUESTS};
 
-lazy_static! {
-    static ref szOID_PKIX_KP_SERVER_AUTH: Vec<u8> = Cryptography::szOID_PKIX_KP_SERVER_AUTH
-        .bytes()
-        .chain(Some(0))
-        .collect();
-    static ref szOID_SERVER_GATED_CRYPTO: Vec<u8> = Cryptography::szOID_SERVER_GATED_CRYPTO
-        .bytes()
-        .chain(Some(0))
-        .collect();
-    static ref szOID_SGC_NETSCAPE: Vec<u8> = Cryptography::szOID_SGC_NETSCAPE
-        .bytes()
-        .chain(Some(0))
-        .collect();
-}
+static szOID_PKIX_KP_SERVER_AUTH: &[u8] = null_terminate!(Cryptography::szOID_PKIX_KP_SERVER_AUTH);
+static szOID_SERVER_GATED_CRYPTO: &[u8] = null_terminate!(Cryptography::szOID_SERVER_GATED_CRYPTO);
+static szOID_SGC_NETSCAPE: &[u8] = null_terminate!(Cryptography::szOID_SGC_NETSCAPE);
 
 /// A builder type for `TlsStream`s.
 pub struct Builder {


### PR DESCRIPTION
Uses a macro to null-terminate static strings at compile time.

This raises the MSRV of this crate to 1.46 due to the need for a loop in const-eval.