### PR TITLE
Use MSI installation files for CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ environment:
   access_token:
     secure: ZxcrtxQXwszRYNN6c1ZIagczEqzmQQZeYHY58izcmF0jdq/cptxJvFUoVxDmnoqj
 install:
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:VERSION}-${env:TARGET}.exe" -FileName "rust-nightly.exe"
-  - ps: .\rust-nightly.exe /VERYSILENT /NORESTART /DIR="C:\rust" | Out-Null
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:VERSION}-${env:TARGET}.msi" -FileName "rust-install.msi"
+  - ps: msiexec /i "rust-install.msi" /qn /norestart INSTALLDIR="C:\rust" | Out-Null
   - ps: $env:PATH="$env:PATH;C:\rust\bin"
   - rustc -vV
   - cargo -vV


### PR DESCRIPTION
I noticed in my other PR (#78) that the CI appears to use a very old rust version, even for nightly.

It turns out that Rust stopped providing .exe installers in 1.46.

This fixes the CI tests to use the latest nightly instead of nightly 1.46.
It also allows increasing the MSRV above 1.40, though this PR doesn't change it.