### PR TITLE
Prevent undefined behavior in context_buffer.rs

### DIFF
--- a/src/context_buffer.rs
+++ b/src/context_buffer.rs
@@ -17,6 +17,10 @@ impl Deref for ContextBuffer {
     type Target = [u8];
 
     fn deref(&self) -> &[u8] {
+        if self.0.cbBuffer == 0 {
+            return &[];
+        }
+        
         unsafe { slice::from_raw_parts(self.0.pvBuffer as *const _, self.0.cbBuffer as usize) }
     }
 }


### PR DESCRIPTION
In some situations, this crate may attempt to dereference a `ContextBuffer` as a `&[u8]` when the context buffer's underlying pointer is null. According to the docs for `slice::from_raw_parts`, this is undefined behavior, and leads to a crash in debug mode on my machine. To work around this, I've added a check for empty context buffers, which returns a constant empty slice instead. This seems to work correctly, but as I'm not familiar with this library, there may be some other invariant being violated. As such, I'm submitting this PR in the hopes that this solves the issue, or at least stimulates some discussion about the problem. Thanks!