### PR TITLE
Bump windows-sys to 0.48.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ edition = "2018"
 default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
-windows-sys = { version = "0.42", features = [
+windows-sys = { version = "0.48", features = [
     "Win32_Foundation", "Win32_Security_Cryptography",
     "Win32_Security_Authentication_Identity", "Win32_Security_Credentials",
     "Win32_System_Memory"] }
 
 [dev-dependencies]
-windows-sys = { version = "0.42", features = ["Win32_System_SystemInformation", "Win32_System_Time"] }
+windows-sys = { version = "0.48", features = ["Win32_System_SystemInformation", "Win32_System_Time"] }

--- a/src/cert_context.rs
+++ b/src/cert_context.rs
@@ -454,7 +454,7 @@ impl CertContext {
     fn set_string(&self, prop: u32, s: &str) -> io::Result<()> {
         unsafe {
             let data = s.encode_utf16().chain(Some(0)).collect::<Vec<_>>();
-            let data = Cryptography::CRYPTOAPI_BLOB {
+            let data = Cryptography::CRYPT_INTEGER_BLOB {
                 cbData: (data.len() * 2) as u32,
                 pbData: data.as_ptr() as *mut _,
             };

--- a/src/cert_store.rs
+++ b/src/cert_store.rs
@@ -156,7 +156,7 @@ impl CertStore {
     /// The password must also be provided to decrypt the encoded data.
     pub fn import_pkcs12(data: &[u8], password: Option<&str>) -> io::Result<CertStore> {
         unsafe {
-            let blob = Cryptography::CRYPTOAPI_BLOB {
+            let blob = Cryptography::CRYPT_INTEGER_BLOB {
                 cbData: data.len() as u32,
                 pbData: data.as_ptr() as *mut u8,
             };
@@ -326,7 +326,7 @@ impl PfxImportOptions {
     /// Imports certificates from a PKCS #12 archive, returning a `CertStore` containing them.
     pub fn import(&self, data: &[u8]) -> io::Result<CertStore> {
         unsafe {
-            let blob = Cryptography::CRYPTOAPI_BLOB {
+            let blob = Cryptography::CRYPT_INTEGER_BLOB {
                 cbData: cmp::min(data.len(), u32::max_value() as usize) as u32,
                 pbData: data.as_ptr() as *mut _,
             };

--- a/src/ctl_context.rs
+++ b/src/ctl_context.rs
@@ -11,8 +11,6 @@ use windows_sys::Win32::Security::Cryptography;
 use crate::cert_context::CertContext;
 use crate::Inner;
 
-static szOID_OIWSEC_sha1: &[u8] = null_terminate!(Cryptography::szOID_OIWSEC_sha1);
-
 /// Wrapped `PCCTL_CONTEXT` which represents a certificate trust list to
 /// Windows.
 pub struct CtlContext(*const Cryptography::CTL_CONTEXT);
@@ -100,7 +98,7 @@ impl Builder {
             ctl_info.dwVersion = Cryptography::CTL_V1;
             ctl_info.SubjectUsage.cUsageIdentifier = usages.len() as u32;
             ctl_info.SubjectUsage.rgpszUsageIdentifier = usages.as_mut_ptr();
-            ctl_info.SubjectAlgorithm.pszObjId = szOID_OIWSEC_sha1.as_ptr() as _;
+            ctl_info.SubjectAlgorithm.pszObjId = Cryptography::szOID_OIWSEC_sha1 as _;
             ctl_info.cCTLEntry = entries.len() as u32;
             ctl_info.rgCTLEntry = entries.as_mut_ptr();
 
@@ -109,7 +107,7 @@ impl Builder {
             let mut encoded_certs = self
                 .certificates
                 .iter()
-                .map(|c| Cryptography::CRYPTOAPI_BLOB {
+                .map(|c| Cryptography::CRYPT_INTEGER_BLOB {
                     cbData: (*c.as_inner()).cbCertEncoded,
                     pbData: (*c.as_inner()).pbCertEncoded,
                 })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,27 +36,6 @@ macro_rules! inner {
     };
 }
 
-macro_rules! null_terminate {
-    ($input:expr) => {{
-        const OUTPUT: [u8; $input.as_bytes().len() + 1] = {
-            let mut output = [0u8; $input.as_bytes().len() + 1];
-
-            let input = $input.as_bytes();
-
-            // The output is 1 byte longer, so the last byte stays initialized to 0
-            let mut i = 0usize;
-            while i < input.len() {
-                output[i] = input[i];
-                i += 1;
-            }
-
-            output
-        };
-
-        &OUTPUT
-    }};
-}
-
 /// Allows access to the underlying schannel API representation of a wrapped data type
 ///
 /// Performing actions with internal handles might lead to the violation of internal assumptions

--- a/src/schannel_cred.rs
+++ b/src/schannel_cred.rs
@@ -10,8 +10,6 @@ use windows_sys::Win32::Security::{Credentials, Cryptography};
 use crate::cert_context::CertContext;
 use crate::Inner;
 
-static UNISP_NAME: &[u8] = null_terminate!(Identity::UNISP_NAME);
-
 /// The communication direction that an `SchannelCred` will support.
 #[derive(Copy, Debug, Clone, PartialEq, Eq)]
 pub enum Direction {
@@ -248,7 +246,7 @@ impl Builder {
 
             match Identity::AcquireCredentialsHandleA(
                 ptr::null(),
-                UNISP_NAME.as_ptr(),
+                Identity::UNISP_NAME_A,
                 direction,
                 ptr::null_mut(),
                 &mut cred_data as *const _ as *const _,

--- a/src/test.rs
+++ b/src/test.rs
@@ -402,8 +402,6 @@ fn session_resumption_thread_safety() {
 
 const FRIENDLY_NAME: &str = "schannel-rs localhost testing cert";
 
-static szOID_RSA_SHA256RSA: &[u8] = null_terminate!(Cryptography::szOID_RSA_SHA256RSA);
-
 fn install_certificate() -> io::Result<CertContext> {
     unsafe {
         let mut provider = 0;
@@ -465,7 +463,7 @@ fn install_certificate() -> io::Result<CertContext> {
             return Err(Error::last_os_error());
         }
 
-        let subject_issuer = Cryptography::CRYPTOAPI_BLOB {
+        let subject_issuer = Cryptography::CRYPT_INTEGER_BLOB {
             cbData: cname_len,
             pbData: cname_buffer.as_ptr() as *mut u8,
         };
@@ -479,7 +477,7 @@ fn install_certificate() -> io::Result<CertContext> {
             dwKeySpec: Cryptography::AT_SIGNATURE,
         };
         let sig_algorithm = Cryptography::CRYPT_ALGORITHM_IDENTIFIER {
-            pszObjId: szOID_RSA_SHA256RSA.as_ptr() as *mut _,
+            pszObjId: Cryptography::szOID_RSA_SHA256RSA as *mut _,
             Parameters: mem::zeroed(),
         };
         let mut expiration_date: Foundation::SYSTEMTIME = mem::zeroed();

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -22,10 +22,6 @@ use crate::schannel_cred::SchannelCred;
 use crate::security_context::SecurityContext;
 use crate::{secbuf, secbuf_desc, Inner, ACCEPT_REQUESTS, INIT_REQUESTS};
 
-static szOID_PKIX_KP_SERVER_AUTH: &[u8] = null_terminate!(Cryptography::szOID_PKIX_KP_SERVER_AUTH);
-static szOID_SERVER_GATED_CRYPTO: &[u8] = null_terminate!(Cryptography::szOID_SERVER_GATED_CRYPTO);
-static szOID_SGC_NETSCAPE: &[u8] = null_terminate!(Cryptography::szOID_SGC_NETSCAPE);
-
 /// A builder type for `TlsStream`s.
 pub struct Builder {
     domain: Option<Vec<u16>>,
@@ -686,9 +682,9 @@ where
             para.RequestedUsage.dwType = Cryptography::USAGE_MATCH_TYPE_OR;
 
             let mut identifiers = [
-                szOID_PKIX_KP_SERVER_AUTH.as_ptr() as _,
-                szOID_SERVER_GATED_CRYPTO.as_ptr() as _,
-                szOID_SGC_NETSCAPE.as_ptr() as _,
+                Cryptography::szOID_PKIX_KP_SERVER_AUTH as _,
+                Cryptography::szOID_SERVER_GATED_CRYPTO as _,
+                Cryptography::szOID_SGC_NETSCAPE as _,
             ];
             para.RequestedUsage.Usage.cUsageIdentifier = identifiers.len() as u32;
             para.RequestedUsage.Usage.rgpszUsageIdentifier = identifiers.as_mut_ptr();


### PR DESCRIPTION
Updated version of https://github.com/steffengy/schannel-rs/pull/89.

Release notes: https://github.com/microsoft/windows-rs/releases/tag/0.48.0

- `CRYPTOAPI_BLOB` renamed to `CRYPT_INTEGER_BLOB`: https://github.com/microsoft/win32metadata/commit/a35703057a1b2a8813154eca0acf1f4e5134a990
- `windows-sys-0.43` changed encoding for all string contants: https://github.com/microsoft/windows-rs/pull/2101
- `null_terminate!` removed as it's no longer needed.
- Use non-wide `UNISP_NAME_A`.
- All tests pass locally (with `SCHANNEL_RS_SKIP_SERVER_TESTS=1` as I don't want to install new certs on my machine).