### PR TITLE
Added function to set exportable private key flag

### DIFF
--- a/src/cert_store.rs
+++ b/src/cert_store.rs
@@ -314,7 +314,7 @@ impl PfxImportOptions {
         )
     }
 
-    /// If set, the private key in the archive will be exportable.
+    /// If set, the private key in the archive will be exportable.    
     pub fn exportable_private_key(
         &mut self,
         exportable_private_key: bool,
@@ -329,6 +329,11 @@ impl PfxImportOptions {
             self.flags &= !flag;
         }
         self
+    }
+
+    /// If set, the private keys are stored under the local computer and not under the current user.
+    pub fn machine_keyset(&mut self, machine_keyset: bool) -> &mut PfxImportOptions {
+        self.flag(Cryptography::CRYPT_MACHINE_KEYSET, machine_keyset)
     }
 
     /// Imports certificates from a PKCS #12 archive, returning a `CertStore` containing them.

--- a/src/cert_store.rs
+++ b/src/cert_store.rs
@@ -314,6 +314,14 @@ impl PfxImportOptions {
         )
     }
 
+    /// If set, the private key in the archive will be exportable.
+    pub fn exportable_private_key(
+        &mut self,
+        exportable_private_key: bool,
+    ) -> &mut PfxImportOptions {
+        self.flag(Cryptography::CRYPT_EXPORTABLE, exportable_private_key)
+    }
+
     fn flag(&mut self, flag: u32, set: bool) -> &mut PfxImportOptions {
         if set {
             self.flags |= flag;


### PR DESCRIPTION
Hi, I needed the exportable flag to be set and this seems to do the trick. It works on my machine (TM). I would appreciate it a lot if you would consider adding it to the library.

This is my first attempt of a PR. I hope I'm doing it correctly.