### PR TITLE
Add PfxImportOptions::named_no_persist_key()

### DIFF
--- a/src/cert_store.rs
+++ b/src/cert_store.rs
@@ -14,6 +14,8 @@ use crate::cert_context::CertContext;
 use crate::ctl_context::CtlContext;
 use crate::Inner;
 
+const PKCS12_NAMED_NO_PERSIST_KEY: u32 = 0x00020000u32;
+
 /// Representation of certificate store on Windows, wrapping a `HCERTSTORE`.
 pub struct CertStore(Cryptography::HCERTSTORE);
 
@@ -303,6 +305,16 @@ impl PfxImportOptions {
         self.flag(Cryptography::PKCS12_NO_PERSIST_KEY, no_persist_key)
     }
 
+    /// If set, the private key in the archive will not be persisted and will be named.
+    ///
+    /// If not set, private keys are persisted on disk and must be manually deleted.
+    pub fn named_no_persist_key(&mut self, no_persist_key: bool) -> &mut PfxImportOptions {
+        #[allow(non_snake_case)]
+        self.flag(PKCS12_NAMED_NO_PERSIST_KEY 
+            | Cryptography::PKCS12_NO_PERSIST_KEY
+            | Cryptography::PKCS12_ALWAYS_CNG_KSP, no_persist_key)
+    }
+
     /// If set, all extended properties of the certificate will be imported.
     pub fn include_extended_properties(
         &mut self,
@@ -335,6 +347,14 @@ impl PfxImportOptions {
             let store = Cryptography::PFXImportCertStore(&blob, password, self.flags);
             if !store.is_null() {
                 Ok(CertStore(store))
+            } else if 0 != (self.flags & PKCS12_NAMED_NO_PERSIST_KEY) {
+                let flags = self.flags & !(Cryptography::PKCS12_NO_PERSIST_KEY | PKCS12_NAMED_NO_PERSIST_KEY);
+                let store = Cryptography::PFXImportCertStore(&blob, password, flags);
+                if !store.is_null() {
+                    Ok(CertStore(store))
+                } else {
+                    Err(io::Error::last_os_error())
+                }
             } else {
                 Err(io::Error::last_os_error())
             }

--- a/src/cert_store.rs
+++ b/src/cert_store.rs
@@ -306,7 +306,7 @@ impl PfxImportOptions {
     }
 
     /// If set, the private key in the archive will not be persisted and will be named.
-    ///
+    /// Named keys are required to be used by schannel.
     /// If not set, private keys are persisted on disk and must be manually deleted.
     pub fn named_no_persist_key(&mut self, no_persist_key: bool) -> &mut PfxImportOptions {
         #[allow(non_snake_case)]

--- a/src/cert_store.rs
+++ b/src/cert_store.rs
@@ -488,4 +488,27 @@ mod test {
             .count();
         assert_eq!(pkeys, 1);
     }
+
+    #[test]
+    fn pfx_import_named_no_persist() {
+        let pfx = include_bytes!("../test/identity.p12");
+        let store = PfxImportOptions::new()
+            .include_extended_properties(true)
+            .password("mypass")
+            .named_no_persist_key(true)
+            .import(pfx)
+            .unwrap();
+        assert_eq!(store.certs().count(), 2);
+        let pkeys = store
+            .certs()
+            .filter(|c| {
+                c.private_key()
+                    .compare_key(true)
+                    .silent(true)
+                    .acquire()
+                    .is_ok()
+            })
+            .count();
+        assert_eq!(pkeys, 1);
+    }
 }


### PR DESCRIPTION
This function sets PKCS12_NAMED_NO_PERSIST_KEY flag for PFXImportCertStore call to import pkcs12 file to prevent Windows from persisting the keys from the pkcs12 file to disk. Without this flag keys imported from pkcs12 files are saved to disk and need to be deleted manually (they are leaked usually).