### PR TITLE
Add minimal TLS1.3 support on supported windows versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   CARGO_INCREMENTAL: 0
@@ -24,6 +24,8 @@ jobs:
           - target: i686-pc-windows-gnu
             channel: 1.60.0
             os: windows-2022
+    env:
+      SCHANNEL_SKIP_TLS_13_TEST: ${{ matrix.os == 'windows-2019' && '1' || '0' }}
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
@@ -32,6 +34,8 @@ jobs:
           target: ${{ matrix.target }}
       - if: matrix.target == 'i686-pc-windows-gnu'
         uses: MinoruSekine/setup-scoop@main
+      - shell: cmd
+        run: echo %SCHANNEL_SKIP_TLS_13_TEST%
       - if: matrix.target == 'i686-pc-windows-gnu'
         run: |
           scoop install -a 32bit mingw

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ default-target = "x86_64-pc-windows-msvc"
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation", "Win32_Security_Cryptography",
     "Win32_Security_Authentication_Identity", "Win32_Security_Credentials",
-    "Win32_System_Memory"] }
+    "Win32_System_LibraryLoader", "Win32_System_Memory"
+] }
 
 [dev-dependencies]
 windows-sys = { version = "0.59", features = ["Win32_System_SystemInformation", "Win32_System_Time"] }

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -839,7 +839,8 @@ where
                 Foundation::SEC_E_OK => {
                     let start = bufs[1].pvBuffer as usize - self.enc_in.get_ref().as_ptr() as usize;
                     let end = start + bufs[1].cbBuffer as usize;
-                    self.dec_in.get_mut().clear();
+                    let dec_in_read_pos = self.dec_in.position() as usize;
+                    self.dec_in.get_mut().drain(..dec_in_read_pos);
                     self.dec_in
                         .get_mut()
                         .extend_from_slice(&self.enc_in.get_ref()[start..end]);


### PR DESCRIPTION
CI only running for server 2022, which seems to support. Fix handling of reads of 2 SEC_E_OKs before first read going through.

Implements #104 