### PR TITLE
Handle empty token when handling `SEC_I_CONTINUE_NEEDED`

### DIFF
--- a/src/context_buffer.rs
+++ b/src/context_buffer.rs
@@ -17,10 +17,6 @@ impl Deref for ContextBuffer {
     type Target = [u8];
 
     fn deref(&self) -> &[u8] {
-        if self.0.cbBuffer == 0 {
-            return &[];
-        }
-        
         unsafe { slice::from_raw_parts(self.0.pvBuffer as *const _, self.0.cbBuffer as usize) }
     }
 }

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -554,11 +554,17 @@ where
                     } else {
                         self.enc_in.position() as usize
                     };
-                    let to_write = ContextBuffer(outbufs[0]);
+                    let to_write = if outbufs[0].pvBuffer.is_null() {
+                        None
+                    } else {
+                        Some(ContextBuffer(outbufs[0]))
+                    };
 
                     self.consume_enc_in(nread);
                     self.needs_read = (self.enc_in.position() == 0) as usize;
-                    self.out_buf.get_mut().extend_from_slice(&to_write);
+                    if let Some(to_write) = to_write {
+                        self.out_buf.get_mut().extend_from_slice(&to_write);
+                    }
                 }
                 Foundation::SEC_E_INCOMPLETE_MESSAGE => {
                     self.needs_read = if inbufs[1].BufferType == Identity::SECBUFFER_MISSING {


### PR DESCRIPTION
Closes #106

When encountering `SEC_I_CONTINUE_NEEDED`, the code assumes the token always exists. However, according to the documentation, the token may be empty:
> The client must send the output token to the server and wait for a return token. The returned token is then passed in another call to [InitializeSecurityContext (General)](https://learn.microsoft.com/en-us/windows/desktop/api/sspi/nf-sspi-initializesecuritycontexta). The output token can be empty.

This causes issues when it gets deref-ed via a `ContextBuffer`, as the pointer is null and slices cannot be created from null pointers.

This was worked around with https://github.com/steffengy/schannel-rs/pull/81, but I think the proper fix is not creating an empty `ContextBuffer` in the first place.

To fix this, I've removed https://github.com/steffengy/schannel-rs/pull/81, reproduced the issue, changed the code by conditionally sending the token like with `SEC_E_OK`, and confirmed that the change fixes the issue. However, I'm not familiar with Windows cryptography APIs, so please check what I've done makes sense.