### PR TITLE
Use `package.include` to only include necessary data for using the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["windows", "schannel", "tls", "ssl", "https"]
 edition = "2018"
 rust-version = "1.71.0"
+include = ["/src/", "LICENSE.md", "README.md"]
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"


### PR DESCRIPTION
This reduces the size of the packaged crate (see the table below), and makes it easier to audit.

|              | before   | after    | percentage change |
|--------------|----------|----------|-------------------|
| uncompressed | 175.5KiB | 158.7KiB |             -9.6% |
| compressed   |  41.6KiB |  32.2KiB |            -22.6% |

Based on the downloads of the previous version, on average, this would reduce the total bandwidth for downloading this crate by 24.5GiB/month.
