### PR TITLE
Fix TLS 1.3 data corruption from double-send during renegotiation

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -948,3 +948,125 @@ fn test_alpn_list() {
         &full_alpn_list as &[u8]
     );
 }
+
+/// This should reproduce renegotiation error on TLS1.3.
+/// It also verifies the same works on TLS1.2 because why not.
+#[test]
+fn test_renegotiation_corruption() {
+    // This did not reproduce with 2 MB so not sure how reliant this test is.
+    let payload_size = 4 * 1024 * 1024;
+    
+    let mut protos = vec![Protocol::Tls12];
+    if std::env::var("SCHANNEL_SKIP_TLS_13_TEST") != Ok("1".to_owned()) {
+        protos.push(Protocol::Tls13);
+    }
+
+    for proto in protos {
+        let mut data_to_send = vec![0u8; payload_size];
+        let pattern = [0,1,2,3,4];
+        for (i, byte) in data_to_send.iter_mut().enumerate() {
+            *byte = pattern[i % pattern.len()];
+        }
+
+        let cert = match localhost_cert() {
+            Some(cert) => cert,
+            None => return,
+        };
+
+        // 1. Setup TCP on random port
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // 2. Server Thread
+        let server_handle = thread::spawn(move || {
+            let (tcp_stream, _) = listener.accept().unwrap();
+            tcp_stream.set_nonblocking(true).unwrap();
+
+            let creds = SchannelCred::builder()
+                .cert(cert)
+                .enabled_protocols(&[proto])
+                .acquire(Direction::Inbound)
+                .unwrap();
+
+            // Drive Handshake
+            let mut res = tls_stream::Builder::new().accept(creds, tcp_stream);
+            let mut stream = loop {
+                match res {
+                    Ok(s) => break s,
+                    Err(crate::tls_stream::HandshakeError::Interrupted(mid)) => {
+                        res = mid.handshake();
+                    }
+                    Err(e) => panic!("Server handshake failed: {:?}", e),
+                }
+            };
+
+            // Server Read Loop
+            let mut received = Vec::with_capacity(payload_size);
+            let mut buf = [0u8; 16384];
+            while received.len() < payload_size {
+                match stream.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => received.extend_from_slice(&buf[..n]),
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => thread::yield_now(),
+                    Err(e) => panic!("Server read error: {:?}", e),
+                }
+            }
+            received
+        });
+
+        // 3. Client Logic
+        let tcp_stream = TcpStream::connect(addr).unwrap();
+        tcp_stream.set_nonblocking(true).unwrap();
+
+        let creds = SchannelCred::builder()
+            .enabled_protocols(&[proto])
+            .acquire(Direction::Outbound)
+            .unwrap();
+
+        // Drive Handshake
+        let mut res = tls_stream::Builder::new()
+            .domain("localhost")
+            .connect(creds, tcp_stream);
+        
+        let mut client_tls = loop {
+            match res {
+                Ok(s) => break s,
+                Err(crate::tls_stream::HandshakeError::Interrupted(mid)) => {
+                    res = mid.handshake();
+                }
+                Err(e) => panic!("Client handshake failed: {:?}", e),
+            }
+        };
+
+        // 4. The Interleaved Write/Read Loop
+        let mut total_sent = 0;
+        while total_sent < payload_size {
+            let chunk = &data_to_send[total_sent..];
+            match client_tls.write(chunk) {
+                Ok(n) => total_sent += n,
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    // FORCE THE ISSUE: 
+                    // While waiting for buffer space, try to read.
+                    // This pulls in the NewSessionTicket and triggers SEC_I_RENEGOTIATE.
+                    let mut dummy = [0u8; 1];
+                    let _ = client_tls.read(&mut dummy);
+                }
+                Err(e) => panic!("Client write error: {:?}", e),
+            }
+        }
+
+        let received_data = server_handle.join().expect("Server thread panicked");
+
+        // 5. Validation
+        assert_eq!(received_data.len(), payload_size, "{:?} Data length mismatch!", proto);
+        let mismatch_count = received_data.iter()
+            .zip(data_to_send.iter())
+            .filter(|(a, b)| a != b)
+            .count();
+
+        // Calculate any difference in length as well
+        let length_diff = (received_data.len() as i128 - data_to_send.len() as i128).abs();
+
+        assert_eq!(mismatch_count, 0, "{:?} DATA CORRUPTION DETECTED: {} bytes do not match (Length diff: {})", proto, mismatch_count, length_diff);
+    }
+}

--- a/src/tls_stream.rs
+++ b/src/tls_stream.rs
@@ -198,6 +198,7 @@ impl Builder {
             out_buf: Cursor::new(buf.map(|b| b.to_owned()).unwrap_or_else(Vec::new)),
             last_write_len: 0,
             requested_application_protocols: self.requested_application_protocols.clone(),
+            is_renegotiating: false,
         };
 
         MidHandshakeTlsStream { inner: stream }.handshake()
@@ -240,6 +241,9 @@ pub struct TlsStream<S> {
     /// the (unencrypted) length of the last write call used to track writes
     last_write_len: usize,
     requested_application_protocols: Option<Vec<Vec<u8>>>,
+    /// set when renegotiation (SEC_I_RENEGOTIATE) fires with pending data in out_buf.
+    /// while set, write_out() is a no-op to prevent double-sending the pending data.
+    is_renegotiating: bool,
 }
 
 /// ensures that a TlsStream is always Sync/Send
@@ -624,6 +628,7 @@ where
                                 sizes: self.context.stream_sizes()?,
                             }
                         };
+                        self.is_renegotiating = false;
                         continue;
                     }
 
@@ -771,6 +776,9 @@ where
     }
 
     fn write_out(&mut self) -> io::Result<usize> {
+        if self.is_renegotiating {
+            return Ok(0);
+        }
         let mut out = 0;
         while self.out_buf.position() as usize != self.out_buf.get_ref().len() {
             let position = self.out_buf.position() as usize;
@@ -869,6 +877,12 @@ where
                         validated: false,
                     };
 
+                    // If there's unsent data in out_buf, flag it so write_out()
+                    // skips sending during renegotiation (avoids double-send).
+                    if (self.out_buf.position() as usize) < self.out_buf.get_ref().len() {
+                        self.is_renegotiating = true;
+                    }
+
                     let nread = if bufs[3].BufferType == Identity::SECBUFFER_EXTRA {
                         self.enc_in.position() as usize - bufs[3].cbBuffer as usize
                     } else {
@@ -889,6 +903,7 @@ where
         sizes: &Identity::SecPkgContext_StreamSizes,
     ) -> io::Result<()> {
         assert!(buf.len() <= sizes.cbMaximumMessage as usize);
+        debug_assert!(!self.is_renegotiating);
 
         unsafe {
             let len = sizes.cbHeader as usize + buf.len() + sizes.cbTrailer as usize;


### PR DESCRIPTION
Let me preface this that I don't regularly develop in Rust so apologies for a naive solution or any idiomatic issues.

---

This is an attempt to address an issue I found while using Reqwest to send large payloads to cloud storage services. When payloads exceed ~1MB, I started seeing TLS Records interspersed in my uploaded data. After digging through the stack I arrived here. I'll try to be succinct with what I found but let me know if you need any extra details.

## Issue
When `read()` and `write()` are interleaved on a non-blocking TLS 1.3 connection (as hyper does in its poll loop), data corruption can occur. The sequence:

1. `write()` encrypts data into `out_buf`, `write_out()` gets `WouldBlock` — encrypted data remains pending in `out_buf`
2. Caller calls `read()` → `fill_buf()` → `read_in()` picks up a TLS 1.3 NewSessionTicket (post-handshake message)
3. `decrypt()` returns `SEC_I_RENEGOTIATE`, transitions state to `Initializing`
4. `fill_buf()` loops → `initialize()` → `write_out()` sends the pending application data from `out_buf`
5. Caller retries `write()` with the same buffer → re-encrypts and sends the same chunk again

The server receives duplicate TLS records, corrupting the payload. This only affects TLS 1.3 because post-handshake messages (NewSessionTicket, KeyUpdate) don't exist in TLS 1.2.

## Proposed Fix
When `SEC_I_RENEGOTIATE` fires and `out_buf` has pending application data, save the current position and advance past it. This prevents `write_out()` inside `initialize()` from sending pending app data during renegotiation. After renegotiation completes, the position is restored so the next `write()` retries normally.

## Reproduction

This issue has been quite hard to reproduce with a localhost server. I'm able to consistently trigger mismatched data uploading >1MB of random data to Azure Blob Storage (or any cloud storage using TLS 1.3) with interleaved `read()`/`write()` on a non-blocking socket. The server's Content-MD5 validation rejects the corrupted upload. Without the fix, uploads fail ~80% of the time. With the fix, I've seen 0 failures across hundreds of test runs.